### PR TITLE
Install roave/security-advisories to prevent insecure dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "^7.0",
         "symfony/symfony": "^3.0",
-        "typo3/cms": "^8.3.0"
+        "typo3/cms": "^8.3.0",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #7
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Install roave/security-advisories package

#### Why?

This prevents all users of Bartacus installing insecure dependencies if they want to install Bartacus or are updating Bartacus.