### PR TITLE
Implement Symfony routing in TypoScript frontend

### DIFF
--- a/Http/Factory/Typo3PsrMessageFactory.php
+++ b/Http/Factory/Typo3PsrMessageFactory.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Http\Factory;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use TYPO3\CMS\Core\Http\Response as Typo3Response;
+use TYPO3\CMS\Core\Http\Stream as Typo3Stream;
+
+/**
+ * Builds Psr\HttpMessage instances using the TYPO3 implementation.
+ *
+ * Based on the Symfony PSR Message bridge.
+ */
+class Typo3PsrMessageFactory implements HttpMessageFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createRequest(Request $symfonyRequest)
+    {
+        throw new \BadMethodCallException('createRequest is not implemented nor will it in the future');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createResponse(Response $symfonyResponse):ResponseInterface
+    {
+        if ($symfonyResponse instanceof BinaryFileResponse) {
+            $stream = new Typo3Stream($symfonyResponse->getFile()->getPathname(), 'r');
+        } else {
+            $stream = new Typo3Stream('php://temp', 'rw');
+            if ($symfonyResponse instanceof StreamedResponse) {
+                ob_start(function ($buffer) use ($stream) {
+                    $stream->write($buffer);
+
+                    return false;
+                });
+
+                $symfonyResponse->sendContent();
+                ob_end_clean();
+            } else {
+                $stream->write($symfonyResponse->getContent());
+            }
+        }
+
+        $headers = $symfonyResponse->headers->all();
+
+        $cookies = $symfonyResponse->headers->getCookies();
+        if (!empty($cookies)) {
+            $headers['Set-Cookie'] = [];
+
+            foreach ($cookies as $cookie) {
+                $headers['Set-Cookie'][] = (string) $cookie;
+            }
+        }
+
+        $response = new Typo3Response(
+            $stream,
+            $symfonyResponse->getStatusCode(),
+            $headers
+        );
+
+        $protocolVersion = $symfonyResponse->getProtocolVersion();
+        if ('1.1' !== $protocolVersion) {
+            $response = $response->withProtocolVersion($protocolVersion);
+        }
+
+        return $response;
+    }
+}

--- a/Http/FrontendApplication.php
+++ b/Http/FrontendApplication.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Http;
+
+use Composer\Autoload\ClassLoader;
+use TYPO3\CMS\Core\Core\ApplicationInterface;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
+use TYPO3\CMS\Frontend\Http\EidRequestHandler;
+
+/**
+ * Entry point for the TYPO3 Frontend
+ */
+class FrontendApplication implements ApplicationInterface
+{
+    /**
+     * @var Bootstrap
+     */
+    protected $bootstrap;
+
+    /**
+     * Number of subdirectories where the entry script is located, relative to PATH_site
+     * Usually this is equal to PATH_site = 0
+     *
+     * @var int
+     */
+    protected $entryPointLevel = 0;
+
+    /**
+     * All available request handlers that can deal with a Frontend Request
+     *
+     * @var array
+     */
+    protected $availableRequestHandlers = [
+        SymfonyFrontendRequestHandler::class,
+        EidRequestHandler::class,
+    ];
+
+    /**
+     * Constructor setting up legacy constant and register available Request Handlers
+     *
+     * @param ClassLoader $classLoader an instance of the class loader
+     */
+    public function __construct(ClassLoader $classLoader)
+    {
+        $this->defineLegacyConstants();
+
+        $this->bootstrap = Bootstrap::getInstance()
+            ->initializeClassLoader($classLoader)
+            ->setRequestType(TYPO3_REQUESTTYPE_FE)
+            ->baseSetup($this->entryPointLevel)
+        ;
+
+        // Redirect to install tool if base configuration is not found
+        if (!$this->bootstrap->checkIfEssentialConfigurationExists()) {
+            $this->bootstrap->redirectToInstallTool($this->entryPointLevel);
+        }
+
+        foreach ($this->availableRequestHandlers as $requestHandler) {
+            $this->bootstrap->registerRequestHandlerImplementation($requestHandler);
+        }
+
+        $this->bootstrap->configure();
+    }
+
+    /**
+     * Starting point
+     *
+     * @param callable $execute
+     */
+    public function run(callable $execute = null)
+    {
+        $this->bootstrap->handleRequest(ServerRequestFactory::fromGlobals());
+
+        if ($execute !== null) {
+            $execute();
+        }
+
+        $this->bootstrap->shutdown();
+    }
+
+    /**
+     * Define constants and variables
+     */
+    protected function defineLegacyConstants()
+    {
+        define('TYPO3_MODE', 'FE');
+    }
+}

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -24,10 +24,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\FrontendEditing\FrontendEditingController;
@@ -419,7 +419,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
 
         // yes, we must use the global declared kernel here, because the request handler is
         // initialized from the Bootstrap with no control of the constructor..
-        /** @var KernelInterface $kernel */
+        /** @var HttpKernelInterface $kernel */
         global $kernel;
 
         $response = null;
@@ -440,8 +440,12 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
             if (0 !== strpos($e->getMessage(), 'No route found for')) {
                 throw $e;
             }
+
+            // Aaaaaaaaaand another ugly hack for the kernel termination :/
+            $symfonyResponse = new SymfonyResponse($e->getMessage(), 404);
         }
 
+        FrontendApplication::setRequestResponseForTermination($symfonyRequest, $symfonyResponse);
         $this->timeTracker->pull();
 
         return $response;

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -199,10 +199,10 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
 
         $response = $this->handleSymfonyRequest($request);
 
-        $addOtherStuffToContent = true;
+        $modifyContent = true;
         if ($response) {
             $sendTSFEContent = true;
-            $addOtherStuffToContent = !empty($this->controller->content);
+            $modifyContent = false;
         } else {
             // Convert POST data to utf-8 for internal processing if metaCharset is different
             $this->controller->convPOSTCharset();
@@ -268,12 +268,12 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
         } else {
             $debugParseTime = !empty($GLOBALS['TYPO3_CONF_VARS']['FE']['debug']);
         }
-        if ($addOtherStuffToContent && $this->controller->isOutputting() && $debugParseTime) {
+        if ($modifyContent && $this->controller->isOutputting() && $debugParseTime) {
             $this->controller->content .= LF.'<!-- Parsetime: '.$this->controller->scriptParseTime.'ms -->';
         }
         $this->controller->redirectToExternalUrl();
         // Preview info
-        if ($addOtherStuffToContent) {
+        if ($modifyContent) {
             $this->controller->previewInfo();
         }
         // Hook for end-of-frontend
@@ -283,12 +283,12 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
         // Check memory usage
         MonitorUtility::peakMemoryUsage();
         // beLoginLinkIPList
-        if ($addOtherStuffToContent) {
+        if ($modifyContent) {
             echo $this->controller->beLoginLinkIPList();
         }
 
         // Admin panel
-        if ($addOtherStuffToContent && $this->controller->isBackendUserLoggedIn() && $GLOBALS['BE_USER'] instanceof FrontendBackendUserAuthentication) {
+        if ($modifyContent && $this->controller->isBackendUserLoggedIn() && $GLOBALS['BE_USER'] instanceof FrontendBackendUserAuthentication) {
             if ($GLOBALS['BE_USER']->isAdminPanelVisible()) {
                 $this->controller->content = str_ireplace('</body>', $GLOBALS['BE_USER']->displayAdminPanel().'</body>',
                     $this->controller->content);
@@ -300,7 +300,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
                 /** @var Response $response */
                 $response = GeneralUtility::makeInstance(Response::class);
                 $response->getBody()->write($this->controller->content);
-            } elseif ($addOtherStuffToContent) {
+            } elseif ($modifyContent) {
                 $response->getBody()->close();
 
                 $body = new Stream('php://temp', 'rw');

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -1,0 +1,464 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Http;
+
+use Bartacus\Bundle\BartacusBundle\Http\Factory\Typo3PsrMessageFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
+use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\FrontendEditing\FrontendEditingController;
+use TYPO3\CMS\Core\Http\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\TimeTracker\TimeTracker;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Core\Utility\MonitorUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageGenerator;
+use TYPO3\CMS\Frontend\Utility\CompressionUtility;
+use TYPO3\CMS\Frontend\View\AdminPanelView;
+
+/**
+ * This is the main entry point of the TypoScript and Symfony combined driven standard front-end
+ *
+ * Basically put, this is the script which all requests for TYPO3 delivered pages goes to in the
+ * frontend (the website). The script instantiates a $TSFE object, includes libraries and does a little logic here
+ * and there in order to instantiate the right classes to create the webpage.
+ *
+ * In between it calls Symfony routes and either executes and returns them, or calls the the real TYPO3 page.
+ */
+class SymfonyFrontendRequestHandler implements RequestHandlerInterface
+{
+    /**
+     * @var Bootstrap
+     */
+    protected $bootstrap;
+
+    /**
+     * @var TimeTracker
+     */
+    protected $timeTracker;
+
+    /**
+     * @var TypoScriptFrontendController
+     */
+    protected $controller;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    protected $request;
+
+    /**
+     * @param Bootstrap $bootstrap
+     */
+    public function __construct(Bootstrap $bootstrap)
+    {
+        $this->bootstrap = $bootstrap;
+    }
+
+    /**
+     * Handles a frontend request
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return null|ResponseInterface
+     */
+    public function handleRequest(ServerRequestInterface $request)
+    {
+        $response = null;
+        $this->request = $request;
+        $this->initializeTimeTracker();
+
+        // Hook to preprocess the current request:
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/index_ts.php']['preprocessRequest'])) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/index_ts.php']['preprocessRequest'] as $hookFunction) {
+                $hookParameters = [];
+                GeneralUtility::callUserFunction($hookFunction, $hookParameters, $hookParameters);
+            }
+            unset($hookFunction, $hookParameters);
+        }
+
+        $this->initializeController();
+
+        if ($GLOBALS['TYPO3_CONF_VARS']['FE']['pageUnavailable_force']
+            && !GeneralUtility::cmpIP(
+                GeneralUtility::getIndpEnv('REMOTE_ADDR'),
+                $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'])
+        ) {
+            $this->controller->pageUnavailableAndExit('This page is temporarily unavailable.');
+        }
+
+        $this->controller->connectToDB();
+        $this->controller->sendRedirect();
+
+        // Output compression
+        // Remove any output produced until now
+        $this->bootstrap->endOutputBufferingAndCleanPreviousOutput();
+        $this->initializeOutputCompression();
+
+        // Initializing the Frontend User
+        $this->timeTracker->push('Front End user initialized', '');
+        $this->controller->initFEuser();
+        $this->timeTracker->pull();
+
+        // Initializing a possible logged-in Backend User
+        /** @var $GLOBALS ['BE_USER'] \TYPO3\CMS\Backend\FrontendBackendUserAuthentication */
+        $GLOBALS['BE_USER'] = $this->controller->initializeBackendUser();
+
+        // Process the ID, type and other parameters.
+        // After this point we have an array, $page in TSFE, which is the page-record
+        // of the current page, $id.
+        $this->timeTracker->push('Process ID', '');
+        // Initialize admin panel since simulation settings are required here:
+        if ($this->controller->isBackendUserLoggedIn()) {
+            $GLOBALS['BE_USER']->initializeAdminPanel();
+            $this->bootstrap
+                ->initializeBackendRouter()
+                ->loadExtensionTables()
+            ;
+        } else {
+            $this->bootstrap->loadCachedTca();
+        }
+        $this->controller->checkAlternativeIdMethods();
+        $this->controller->clear_preview();
+        $this->controller->determineId();
+
+        // Now, if there is a backend user logged in and he has NO access to this page,
+        // then re-evaluate the id shown! _GP('ADMCMD_noBeUser') is placed here because
+        // \TYPO3\CMS\Version\Hook\PreviewHook might need to know if a backend user is logged in.
+        if (
+            $this->controller->isBackendUserLoggedIn()
+            && (!$GLOBALS['BE_USER']->extPageReadAccess($this->controller->page) || GeneralUtility::_GP('ADMCMD_noBeUser'))
+        ) {
+            // Remove user
+            unset($GLOBALS['BE_USER']);
+            $this->controller->beUserLogin = false;
+            // Re-evaluate the page-id.
+            $this->controller->checkAlternativeIdMethods();
+            $this->controller->clear_preview();
+            $this->controller->determineId();
+        }
+
+        $this->controller->makeCacheHash();
+        $this->timeTracker->pull();
+
+        // Admin Panel & Frontend editing
+        if ($this->controller->isBackendUserLoggedIn()) {
+            $GLOBALS['BE_USER']->initializeFrontendEdit();
+            if ($GLOBALS['BE_USER']->adminPanel instanceof AdminPanelView) {
+                $this->bootstrap->initializeLanguageObject();
+            }
+            if ($GLOBALS['BE_USER']->frontendEdit instanceof FrontendEditingController) {
+                $GLOBALS['BE_USER']->frontendEdit->initConfigOptions();
+            }
+        }
+
+        // Starts the template
+        $this->timeTracker->push('Start Template', '');
+        $this->controller->initTemplate();
+        $this->timeTracker->pull();
+        // Get from cache
+        $this->timeTracker->push('Get Page from cache', '');
+        $this->controller->getFromCache();
+        $this->timeTracker->pull();
+        // Get config if not already gotten
+        // After this, we should have a valid config-array ready
+        $this->controller->getConfigArray();
+        // Setting language and locale
+        $this->timeTracker->push('Setting language and locale', '');
+        $this->controller->settingLanguage();
+        $this->controller->settingLocale();
+        $this->timeTracker->pull();
+
+        $response = $this->handleSymfonyRequest($request);
+
+        $addOtherStuffToContent = true;
+        if ($response) {
+            $sendTSFEContent = true;
+            $addOtherStuffToContent = !empty($this->controller->content);
+        } else {
+            // Convert POST data to utf-8 for internal processing if metaCharset is different
+            $this->controller->convPOSTCharset();
+
+            $this->controller->initializeRedirectUrlHandlers();
+
+            $this->controller->handleDataSubmission();
+            // Check for shortcut page and redirect
+            $this->controller->checkPageForShortcutRedirect();
+            $this->controller->checkPageForMountpointRedirect();
+
+            // Generate page
+            $this->controller->setUrlIdToken();
+            $this->timeTracker->push('Page generation', '');
+            if ($this->controller->isGeneratePage()) {
+                $this->controller->generatePage_preProcessing();
+                $temp_theScript = $this->controller->generatePage_whichScript();
+                if ($temp_theScript) {
+                    include $temp_theScript;
+                } else {
+                    PageGenerator::pagegenInit();
+                    // Global content object
+                    $this->controller->newCObj();
+                    // Content generation
+                    if (!$this->controller->isINTincScript()) {
+                        PageGenerator::renderContent();
+                        $this->controller->setAbsRefPrefix();
+                    }
+                }
+                $this->controller->generatePage_postProcessing();
+            } elseif ($this->controller->isINTincScript()) {
+                PageGenerator::pagegenInit();
+                // Global content object
+                $this->controller->newCObj();
+            }
+            $this->controller->releaseLocks();
+            $this->timeTracker->pull();
+
+            // Render non-cached parts
+            if ($this->controller->isINTincScript()) {
+                $this->timeTracker->push('Non-cached objects', '');
+                $this->controller->INTincScript();
+                $this->timeTracker->pull();
+            }
+
+            // Output content
+            $sendTSFEContent = false;
+            if ($this->controller->isOutputting()) {
+                $this->timeTracker->push('Print Content', '');
+                $this->controller->processOutput();
+                $sendTSFEContent = true;
+                $this->timeTracker->pull();
+            }
+        }
+
+        // Store session data for fe_users
+        $this->controller->storeSessionData();
+        // Statistics
+        $GLOBALS['TYPO3_MISC']['microtime_end'] = microtime(true);
+        $this->controller->setParseTime();
+        if (isset($this->controller->config['config']['debug'])) {
+            $debugParseTime = (bool) $this->controller->config['config']['debug'];
+        } else {
+            $debugParseTime = !empty($GLOBALS['TYPO3_CONF_VARS']['FE']['debug']);
+        }
+        if ($addOtherStuffToContent && $this->controller->isOutputting() && $debugParseTime) {
+            $this->controller->content .= LF.'<!-- Parsetime: '.$this->controller->scriptParseTime.'ms -->';
+        }
+        $this->controller->redirectToExternalUrl();
+        // Preview info
+        if ($addOtherStuffToContent) {
+            $this->controller->previewInfo();
+        }
+        // Hook for end-of-frontend
+        $this->controller->hook_eofe();
+        // Finish timetracking
+        $this->timeTracker->pull();
+        // Check memory usage
+        MonitorUtility::peakMemoryUsage();
+        // beLoginLinkIPList
+        if ($addOtherStuffToContent) {
+            echo $this->controller->beLoginLinkIPList();
+        }
+
+        // Admin panel
+        if ($addOtherStuffToContent && $this->controller->isBackendUserLoggedIn() && $GLOBALS['BE_USER'] instanceof FrontendBackendUserAuthentication) {
+            if ($GLOBALS['BE_USER']->isAdminPanelVisible()) {
+                $this->controller->content = str_ireplace('</body>', $GLOBALS['BE_USER']->displayAdminPanel().'</body>',
+                    $this->controller->content);
+            }
+        }
+
+        if ($sendTSFEContent) {
+            if (!$response) {
+                /** @var Response $response */
+                $response = GeneralUtility::makeInstance(Response::class);
+                $response->getBody()->write($this->controller->content);
+            } elseif ($addOtherStuffToContent) {
+                $response->getBody()->close();
+
+                $body = new Stream('php://temp', 'rw');
+                $body->write($this->controller->content);
+                $response = $response->withBody($body);
+            }
+        }
+        // Debugging Output
+        if (isset($GLOBALS['error']) && is_object($GLOBALS['error']) && @is_callable([
+                $GLOBALS['error'],
+                'debugOutput',
+            ])
+        ) {
+            $GLOBALS['error']->debugOutput();
+        }
+        if (TYPO3_DLOG) {
+            GeneralUtility::devLog('END of FRONTEND session', 'cms', 0, ['_FLUSH' => true]);
+        }
+
+        return $response;
+    }
+
+    /**
+     * This request handler can handle any frontend request.
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return bool If the request is not an eID request, TRUE otherwise FALSE
+     */
+    public function canHandleRequest(ServerRequestInterface $request):bool
+    {
+        return $request->getQueryParams()['eID'] || $request->getParsedBody()['eID'] ? false : true;
+    }
+
+    /**
+     * Returns the priority - how eager the handler is to actually handle the
+     * request.
+     *
+     * @return int The priority of the request handler.
+     */
+    public function getPriority():int
+    {
+        return 50;
+    }
+
+    /**
+     * Initializes output compression when enabled, could be split up and put into Bootstrap
+     * at a later point
+     */
+    protected function initializeOutputCompression()
+    {
+        if ($GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'] && extension_loaded('zlib')) {
+            if (MathUtility::canBeInterpretedAsInteger($GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'])) {
+                @ini_set('zlib.output_compression_level', $GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']);
+            }
+            ob_start([GeneralUtility::makeInstance(CompressionUtility::class), 'compressionOutputHandler']);
+        }
+    }
+
+    /**
+     * Timetracking started depending if a Backend User is logged in
+     *
+     * @return void
+     */
+    protected function initializeTimeTracker()
+    {
+        $configuredCookieName = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
+
+        /** @var TimeTracker timeTracker */
+        $this->timeTracker = GeneralUtility::makeInstance(TimeTracker::class,
+            ($this->request->getCookieParams()[$configuredCookieName] ? true : false));
+        $this->timeTracker->start();
+    }
+
+    /**
+     * Creates an instance of TSFE and sets it as a global variable
+     *
+     * @return void
+     */
+    protected function initializeController()
+    {
+        $this->controller = GeneralUtility::makeInstance(
+            TypoScriptFrontendController::class,
+            null,
+            GeneralUtility::_GP('id'),
+            GeneralUtility::_GP('type'),
+            GeneralUtility::_GP('no_cache'),
+            GeneralUtility::_GP('cHash'),
+            null,
+            GeneralUtility::_GP('MP'),
+            GeneralUtility::_GP('RDCT')
+        );
+        // setting the global variable for the controller
+        // We have to define this as reference here, because there is code around
+        // which exchanges the TSFE object in the global variable. The reference ensures
+        // that the $controller member always works on the same object as the global variable.
+        // This is a dirty workaround and bypasses the protected access modifier of the controller member.
+        $GLOBALS['TSFE'] = &$this->controller;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     *
+     * @return ResponseInterface
+     */
+    protected function handleSymfonyRequest(ServerRequestInterface $request):ResponseInterface
+    {
+        $this->timeTracker->push('Symfony request handling', '');
+
+        if ($request instanceof ServerRequest) {
+            $this->fixRequest($request);
+        }
+
+        $httpFoundationFactory = new HttpFoundationFactory();
+        $symfonyRequest = $httpFoundationFactory->createRequest($request);
+
+        // yes, we must use the global declared kernel here, because the request handler is
+        // initialized from the Bootstrap with no control of the constructor..
+        /** @var KernelInterface $kernel */
+        global $kernel;
+        $symfonyResponse = $kernel->handle($symfonyRequest);
+        if (!$symfonyResponse instanceof BinaryFileResponse
+            && !$symfonyResponse instanceof StreamedResponse
+            && 0 === stripos($symfonyResponse->headers->get('Content-Type'), 'text/html')
+        ) {
+            $this->controller->content = $symfonyResponse->getContent();
+        }
+
+        $psr7Factory = new Typo3PsrMessageFactory();
+        $response = $psr7Factory->createResponse($symfonyResponse);
+
+        $this->timeTracker->pull();
+
+        return $response;
+    }
+
+    /**
+     * Fixes the request object, because its properties are not properly initialized as arrays.
+     * @deprecated and should be removed when https://forge.typo3.org/issues/77989 is fixed
+     *
+     * @param ServerRequest $request
+     */
+    private function fixRequest(ServerRequest $request)
+    {
+        $refObj = new \ReflectionObject($request);
+
+        $refQueryParams = $refObj->getProperty('queryParams');
+        $refQueryParams->setAccessible(true);
+
+        $queryParams = $refQueryParams->getValue($request);
+        if (null === $queryParams) {
+            $refQueryParams->setValue($request, []);
+        }
+
+        $refAttributes = $refObj->getProperty('attributes');
+        $refAttributes->setAccessible(true);
+
+        $attributes = $refAttributes->getValue($request);
+        if (null === $attributes) {
+            $refAttributes->setValue($request, []);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "7.0.*",
         "symfony/symfony": "^3.0",
-        "typo3/cms": "^8.3.0",
+        "typo3/cms": "8.3.*",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "7.0.*",
         "symfony/symfony": "^3.0",
+        "symfony/psr-http-message-bridge": "^1.0",
         "typo3/cms": "8.3.*",
         "roave/security-advisories": "dev-master"
     },

--- a/dynamicReturnTypeMeta.json
+++ b/dynamicReturnTypeMeta.json
@@ -1,0 +1,35 @@
+{
+	// configuration file for PHPStorm Plugin: http://plugins.jetbrains.com/plugin/7251
+	"methodCalls": [
+		{
+			"class": "\\TYPO3\\CMS\\Core\\Utility\\GeneralUtility",
+			"method": "makeInstance",
+			"position": 0
+		},
+		{
+			"class": "\\TYPO3\\CMS\\Extbase\\Object\\ObjectManagerInterface",
+			"method": "get",
+			"position": 0
+		},
+		{
+			"class": "\\PHPUnit_Framework_TestCase",
+			"method": "prophesize",
+			"position": 0,
+			"mask": "%s|\\Prophecy\\Prophecy\\ObjectProphecy"
+		},
+		{
+			"class": "\\PHPUnit_Framework_TestCase",
+			"method": "getMock",
+			"position": 0,
+			"mask": "%s|\\PHPUnit_Framework_MockObject_MockObject"
+		},
+		{
+			"class": "\\PHPUnit_Framework_TestCase",
+			"method": "createMock",
+			"position": 0,
+			"mask": "%s|\\PHPUnit_Framework_MockObject_MockObject"
+		},
+	],
+	"functionCalls": [
+	]
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #10 
| Related issues/PRs | Bartacus/Bartacus-Standard#8
| License | GPL-3.0+

#### What's in this PR?

Integrates the standard symfony kernel dispatch into the TypoScript frontend handling of TYPO3.

### Caveats

Needed to copy the application and request handler class from typo3 and adapt it. Will be annoying to maintain.

Also has a temporary reflection hack to fix the PSR-7 implementation from typo3: https://forge.typo3.org/issues/77989