### PR TITLE
Load TypoScript user functions from service container

### DIFF
--- a/BartacusBundle.php
+++ b/BartacusBundle.php
@@ -19,8 +19,25 @@
 
 namespace Bartacus\Bundle\BartacusBundle;
 
+use Bartacus\Bundle\BartacusBundle\DependencyInjection\Compiler\TypoScriptUserFuncPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class BartacusBundle extends Bundle
 {
+    /**
+     * @inheritDoc
+     */
+    public function boot()
+    {
+        $this->container->get('bartacus.typoscript.user_func_collector')->loadUserFuncs();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new TypoScriptUserFuncPass());
+    }
 }

--- a/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
+++ b/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TypoScriptUserFuncPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('bartacus.typoscript.user_func_collector')) {
+            return;
+        }
+
+        $definition = $container->findDefinition(
+            'bartacus.typoscript.user_func_collector'
+        );
+
+        $taggedServices = $container->findTaggedServiceIds(
+            'bartacus.typoscript'
+        );
+
+        foreach ($taggedServices as $id => $tags) {
+            $taggedDefinition = $container->findDefinition($id);
+            $taggedDefinition->setLazy(true);
+
+            $definition->addMethodCall(
+                'addUserFunc',
+                [$taggedDefinition->getClass(), new Reference($id)]
+            );
+        }
+    }
+}

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -21,3 +21,4 @@ Contents
     :maxdepth: 2
 
     getting-started/index
+    services_typoscript

--- a/Resources/doc/services_typoscript.rst
+++ b/Resources/doc/services_typoscript.rst
@@ -1,0 +1,45 @@
+======================
+Services in TypoScript
+======================
+
+Symfony has an excellent service container with dependency injection. But in a
+while you have to configure some user function in TypoScript which are
+expecting the class name. This would prevent the use of proper DI.
+
+Fortunately Bartacus integrates the service container into TYPO3 so your access
+to configured classes in TypoScript is automatically transformed into a (lazy)
+service container load.
+
+TypoScript user functions
+=========================
+
+Define your class as service with the tag ``bartacus.typoscript``. For more
+information about the service container see the
+`Symfony Service Container Documentation <http://symfony.com/doc/current/book/service_container.html>`_.
+
+
+.. code-block:: php
+
+    namespace AppBundle\TypoScript;
+
+    use JMS\DiExtraBundle\Annotation as DI;
+
+    /**
+     * @DI\Service()
+     * @DI\Tag("bartacus.typoscript")
+     */
+    class PageTitle
+    {
+        // ...
+    }
+
+Now you can use your class in your TypoScript user funcs and the service will
+be initialized.
+
+.. code-block:: text
+
+    site.config.titleTagFunction = AppBundle\TypoScript\PageTitle->getPageTitle
+
+Normally you would get passed the calling ``ContentObjectRender`` passed into a
+public property ``cObj``. When using services for user functions you get passed
+the calling content object as third parameter to the method.

--- a/TypoScript/UserFuncCollector.php
+++ b/TypoScript/UserFuncCollector.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\TypoScript;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Collects all classes which should be usable for TypoScript userFunc calls.
+ *
+ * @DI\Service("bartacus.typoscript.user_func_collector")
+ */
+class UserFuncCollector
+{
+    /**
+     * The tagged services for userFunc calls
+     *
+     * [class name => instance]
+     *
+     * @var array
+     */
+    protected $userFuncs = [];
+
+    /**
+     * @param string $className
+     * @param object $instance
+     * @param array  $methods
+     */
+    public function addUserFunc(string $className, $instance)
+    {
+        $this->userFuncs[$className] = $instance;
+    }
+
+    /**
+     * Loads all registered instances into the {@see GeneralUtility::makeInstance()} singleton cache.
+     */
+    public function loadUserFuncs()
+    {
+        $refl = new \ReflectionClass(GeneralUtility::class);
+        $reflProp = $refl->getProperty('singletonInstances');
+        $reflProp->setAccessible(true);
+
+        $instances = $reflProp->getValue();
+        $instances = array_merge($instances, $this->userFuncs);
+
+        $reflProp->setValue(null, $instances);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/symfony": "^3.0",
         "symfony/psr-http-message-bridge": "^1.0",
         "jms/di-extra-bundle": "^1.8",
+        "ocramius/proxy-manager": "^2.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #8
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

This loads calls to tagged service class names from the service container.

#### Caveats

This misuses the `GeneralUtility::$singletonInstances` cache to register the lazy service instance for the tagged service class name. This would prevent using XCLASS on this service classes, but they are 100% your own classes or Bartacus bundle ones, this will be never a use case.

#### Sideffects

This should work for hooks user objects and user functions too. Not tested yet.