### PR TITLE
Render TYPO3 content elements with Symfony controllers

### DIFF
--- a/Annotation/ContentElement.php
+++ b/Annotation/ContentElement.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Annotation;
+
+/**
+ * Define a Symfony controller actions as TYPO3 content element handler.
+ *
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+final class ContentElement
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $cached = true;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        if (isset($options['value'])) {
+            $this->name = (string) $options['value'];
+        } else {
+            throw new \InvalidArgumentException('Name value does not exist');
+        }
+
+        if (isset($options['cached'])) {
+            $this->cached = filter_var($options['cached'], FILTER_VALIDATE_BOOLEAN);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isCached(): bool
+    {
+        return $this->cached;
+    }
+}

--- a/CacheWarmer/ContentElementCacheWarmer.php
+++ b/CacheWarmer/ContentElementCacheWarmer.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\CacheWarmer;
+
+use Bartacus\Bundle\BartacusBundle\ContentElement\ContentElementConfigLoader;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+
+/**
+ * @DI\Service("bartacus.content_element.cache_warmer")
+ * @DI\Tag("kernel.cache_warmer")
+ */
+class ContentElementCacheWarmer implements CacheWarmerInterface
+{
+    protected $configLoader;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "configLoader" = @DI\Inject("bartacus.content_element.config_loader")
+     * })
+     */
+    public function __construct(ContentElementConfigLoader $configLoader)
+    {
+        $this->configLoader = $configLoader;
+    }
+
+    /**
+     * Warms up the cache.
+     *
+     * @param string $cacheDir The cache directory
+     */
+    public function warmUp($cacheDir)
+    {
+        if ($this->configLoader instanceof WarmableInterface) {
+            $this->configLoader->warmUp($cacheDir);
+        }
+    }
+
+    /**
+     * Checks whether this warmer is optional or not.
+     *
+     * @return bool always true
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+}

--- a/Config/ConfigLoader.php
+++ b/Config/ConfigLoader.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Config;
+
+use Bartacus\Bundle\BartacusBundle\ContentElement\ContentElementConfigLoader;
+use JMS\DiExtraBundle\Annotation as DI;
+
+/**
+ * Delegating central config loader called on various places within TYPO3
+ * to load and configure specific parts of the system.
+ *
+ * @DI\Service("bartacus.config_loader")
+ */
+class ConfigLoader
+{
+    /**
+     * @var ContentElementConfigLoader
+     */
+    protected $contentElement;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "contentElement" = @DI\Inject("bartacus.content_element.config_loader")
+     * })
+     *
+     * @param ContentElementConfigLoader $contentElement
+     */
+    public function __construct(ContentElementConfigLoader $contentElement)
+    {
+        $this->contentElement = $contentElement;
+    }
+
+    public function loadFromAdditionalConfiguration()
+    {
+        $this->contentElement->load();
+    }
+}

--- a/ContentElement/ContentElementConfigLoader.php
+++ b/ContentElement/ContentElementConfigLoader.php
@@ -1,0 +1,219 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\ContentElement;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * @DI\Service("bartacus.content_element.config_loader", public=false)
+ */
+class ContentElementConfigLoader
+{
+    /**
+     * @var RenderDefinitionCollection|null
+     */
+    protected $collection;
+
+    /**
+     * @var string[]
+     */
+    protected $bundles = [];
+
+    /**
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var bool
+     */
+    private $typoScriptLoaded = false;
+
+    /**
+     * @var ConfigCacheFactoryInterface
+     */
+    private $configCacheFactory;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "container" = @DI\Inject("service_container"),
+     *      "bundles" = @DI\Inject("%jms_di_extra.bundles%"),
+     *      "cacheDir" = @DI\Inject("%kernel.cache_dir%"),
+     *      "debug" = @DI\Inject("%kernel.debug%")
+     * })
+     */
+    public function __construct(ContainerInterface $container, array $bundles = [], string $cacheDir = null, bool $debug = false)
+    {
+        $this->container = $container;
+        $this->bundles = $bundles;
+        $this->setOptions([
+            'cache_dir' => $cacheDir,
+            'debug' => $debug,
+        ]);
+    }
+
+    /**
+     * Sets options.
+     *
+     * Available options:
+     *
+     *   * cache_dir:     The cache directory (or null to disable caching)
+     *   * debug:         Whether to enable debugging or not (false by default)
+     *
+     * @param array $options An array of options
+     *
+     * @throws \InvalidArgumentException When unsupported option is provided
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = [
+            'cache_dir' => null,
+            'debug' => false,
+        ];
+
+        // check option names and live merge, if errors are encountered Exception will be thrown
+        $invalid = [];
+        foreach ($options as $key => $value) {
+            if (array_key_exists($key, $this->options)) {
+                $this->options[$key] = $value;
+            } else {
+                $invalid[] = $key;
+            }
+        }
+
+        if ($invalid) {
+            throw new \InvalidArgumentException(sprintf(
+                'The Content Element loader does not support the following options: "%s".',
+                implode('", "', $invalid)
+            ));
+        }
+    }
+
+    public function load()
+    {
+        if (true === $this->typoScriptLoaded) {
+            return;
+        }
+
+        if (null === $this->options['cache_dir']) {
+            $renderDefinitions = $this->getRenderDefinitionCollection();
+
+            foreach ($renderDefinitions as $renderDefinition) {
+                ExtensionManagementUtility::addTypoScript(
+                    'Bartacus',
+                    'setup',
+                    $this->renderPluginContent($renderDefinition),
+                    'defaultContentRendering'
+                );
+            }
+
+            $this->typoScriptLoaded = true;
+
+            return;
+        }
+
+        $cache = $this->getConfigCacheFactory()
+            ->cache($this->options['cache_dir'].'/content_elements.ts',
+                function (ConfigCacheInterface $cache) {
+                    $renderDefinitions = $this->getRenderDefinitionCollection();
+
+                    $typoScripts = [];
+                    foreach ($renderDefinitions as $renderDefinition) {
+                        $typoScripts[] = $this->renderPluginContent($renderDefinition);
+                    }
+
+                    $output = implode("\n\n", $typoScripts);
+                    $cache->write($output, $renderDefinitions->getResources());
+                }
+            )
+        ;
+
+        ExtensionManagementUtility::addTypoScript(
+            'Bartacus',
+            'setup',
+            file_get_contents($cache->getPath()),
+            'defaultContentRendering'
+        );
+    }
+
+    /**
+     * @return RenderDefinitionCollection
+     *
+     * @throws \Exception
+     */
+    private function getRenderDefinitionCollection(): RenderDefinitionCollection
+    {
+        if (null === $this->collection) {
+            $this->collection = $this->container
+                ->get('bartacus.content_element.loader')
+                ->load($this->bundles, 'annotation')
+            ;
+        }
+
+        return $this->collection;
+    }
+
+    /**
+     * @param RenderDefinition $renderDefinition
+     *
+     * @return string
+     */
+    private function renderPluginContent(RenderDefinition $renderDefinition): string
+    {
+        $pluginSignature = $renderDefinition->getName();
+        $cached = $renderDefinition->isCached();
+        $controller = $renderDefinition->getController();
+
+        $pluginContent = trim('
+# Setting '.$pluginSignature.' content element TypoScript
+tt_content.'.$pluginSignature.' = USER'.($cached ? '' : '_INT').'
+tt_content.'.$pluginSignature.' {
+    userFunc = '.Renderer::class.'->handle
+    controller = '.$controller.'
+}');
+
+        return $pluginContent;
+    }
+
+    /**
+     * Provides the ConfigCache factory implementation, falling back to a
+     * default implementation if necessary.
+     *
+     * @return ConfigCacheFactoryInterface $configCacheFactory
+     */
+    private function getConfigCacheFactory(): ConfigCacheFactoryInterface
+    {
+        if (null === $this->configCacheFactory) {
+            $this->configCacheFactory = new ConfigCacheFactory($this->options['debug']);
+        }
+
+        return $this->configCacheFactory;
+    }
+}

--- a/ContentElement/Loader/AnnotationBundleLoader.php
+++ b/ContentElement/Loader/AnnotationBundleLoader.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\ContentElement\Loader;
+
+use Bartacus\Bundle\BartacusBundle\ContentElement\RenderDefinitionCollection;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Config\Resource\DirectoryResource;
+
+/**
+ * @DI\Service("bartacus.content_element.loader")
+ */
+class AnnotationBundleLoader extends FileLoader
+{
+    /**
+     * @var AnnotationClassLoader
+     */
+    private $loader;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "locator" = @DI\Inject("file_locator"),
+     *      "loader" = @DI\Inject("bartacus.content_element.class_loader")
+     * })
+     */
+    public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader)
+    {
+        if (!function_exists('token_get_all')) {
+            throw new \RuntimeException('The Tokenizer extension is required for the routing annotation loaders.');
+        }
+
+        parent::__construct($locator);
+
+        $this->loader = $loader;
+    }
+
+    /**
+     * Loads from annotations from bundles.
+     *
+     * @param array       $bundles A array of bundles
+     * @param string|null $type    The resource type
+     *
+     * @return RenderDefinitionCollection
+     *
+     * @throws \Exception
+     */
+    public function load($bundles, $type = null): RenderDefinitionCollection
+    {
+        $collection = new RenderDefinitionCollection();
+        foreach ($bundles as $bundle) {
+            try {
+                $dir = $this->locator->locate('@'.$bundle.'/Controller/');
+            } catch (\Exception $e) {
+                // No controllers in that bundle..
+                continue;
+            }
+
+            $collection->addResource(new DirectoryResource($dir, '/\.php$/'));
+            $files = iterator_to_array(
+                new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($dir),
+                    \RecursiveIteratorIterator::LEAVES_ONLY
+                )
+            );
+
+            usort($files, function (\SplFileInfo $a, \SplFileInfo $b) {
+                return (string) $a > (string) $b ? 1 : -1;
+            });
+
+            /** @var \SplFileInfo $file */
+            foreach ($files as $file) {
+                if (!$file->isFile() || '.php' !== substr($file->getFilename(), -4)) {
+                    continue;
+                }
+
+                $class = $this->findClass($file);
+                if ($class) {
+                    $refl = new \ReflectionClass($class);
+                    if ($refl->isAbstract()) {
+                        continue;
+                    }
+
+                    $collection->addCollection($this->loader->load($class, $type));
+                }
+
+                if (PHP_VERSION_ID >= 70000) {
+                    // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
+                    gc_mem_caches();
+                }
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($bundles, $type = null): bool
+    {
+        if (!is_array($bundles)) {
+            return false;
+        }
+
+        return 'annotation' === $type;
+    }
+
+    /**
+     * Returns the full class name for the first class in the file.
+     *
+     * @param string $file A PHP file path
+     *
+     * @return string|false Full class name if found, false otherwise
+     */
+    protected function findClass($file)
+    {
+        $class = false;
+        $namespace = false;
+        $tokens = token_get_all(file_get_contents((string) $file));
+        for ($i = 0; isset($tokens[$i]); ++$i) {
+            $token = $tokens[$i];
+
+            if (!isset($token[1])) {
+                continue;
+            }
+
+            if (true === $class && T_STRING === $token[0]) {
+                return $namespace.'\\'.$token[1];
+            }
+
+            if (true === $namespace && T_STRING === $token[0]) {
+                $namespace = $token[1];
+                while (isset($tokens[++$i][1]) && in_array($tokens[$i][0], [T_NS_SEPARATOR, T_STRING])) {
+                    $namespace .= $tokens[$i][1];
+                }
+                $token = $tokens[$i];
+            }
+
+            if (T_CLASS === $token[0]) {
+                // Skip usage of ::class constant
+                $isClassConstant = false;
+                for ($j = $i - 1; $j > 0; --$j) {
+                    if (!isset($tokens[$j][1])) {
+                        break;
+                    }
+
+                    if (T_DOUBLE_COLON === $tokens[$j][0]) {
+                        $isClassConstant = true;
+                        break;
+                    } elseif (!in_array($tokens[$j][0], [T_WHITESPACE, T_DOC_COMMENT, T_COMMENT])) {
+                        break;
+                    }
+                }
+
+                if (!$isClassConstant) {
+                    $class = true;
+                }
+            }
+
+            if (T_NAMESPACE === $token[0]) {
+                $namespace = true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/ContentElement/Loader/AnnotationClassLoader.php
+++ b/ContentElement/Loader/AnnotationClassLoader.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\ContentElement\Loader;
+
+use Bartacus\Bundle\BartacusBundle\Annotation\ContentElement;
+use Bartacus\Bundle\BartacusBundle\ContentElement\RenderDefinition;
+use Bartacus\Bundle\BartacusBundle\ContentElement\RenderDefinitionCollection;
+use Doctrine\Common\Annotations\Reader;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * @DI\Service("bartacus.content_element.class_loader", public=false)
+ */
+class AnnotationClassLoader implements LoaderInterface
+{
+    /**
+     * @var Reader
+     */
+    protected $reader;
+
+    /**
+     * @var int
+     */
+    protected $defaultRenderDefinitionIndex = 0;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "reader" = @DI\Inject("annotation_reader")
+     * })
+     */
+    public function __construct(Reader $reader)
+    {
+        $this->reader = $reader;
+    }
+
+    /**
+     * Loads from annotations from a class.
+     *
+     * @param string      $class A class name
+     * @param string|null $type  The resource type
+     *
+     * @return RenderDefinitionCollection
+     *
+     * @throws \InvalidArgumentException When render defintion can't be parsed
+     */
+    public function load($class, $type = null): RenderDefinitionCollection
+    {
+        if (!class_exists($class)) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" does not exist.', $class));
+        }
+
+        $class = new \ReflectionClass($class);
+        if ($class->isAbstract()) {
+            throw new \InvalidArgumentException(sprintf('Annotations from class "%s" cannot be read as it is abstract.',
+                $class->getName()));
+        }
+
+        $collection = new RenderDefinitionCollection();
+        $collection->addResource(new FileResource($class->getFileName()));
+
+        foreach ($class->getMethods() as $method) {
+            $this->defaultRenderDefinitionIndex = 0;
+            foreach ($this->reader->getMethodAnnotations($method) as $annot) {
+                if ($annot instanceof ContentElement) {
+                    $this->addRenderDefinition($collection, $annot, $class, $method);
+                }
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($class, $type = null): bool
+    {
+        return is_string($class) && preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$/', $class)
+        && (!$type || 'annotation' === $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setResolver(LoaderResolverInterface $resolver)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResolver()
+    {
+    }
+
+    protected function addRenderDefinition(RenderDefinitionCollection $collection, ContentElement $annot, \ReflectionClass $class, \ReflectionMethod $method)
+    {
+        $name = $annot->getName();
+        if (null === $name) {
+            $name = $this->getDefaultName($class, $method);
+        }
+        $cached = $annot->isCached();
+
+        $renderDefinition = new RenderDefinition($name, $cached, $class->getName().'::'.$method->getName());
+        $collection->add($renderDefinition);
+    }
+
+    protected function getDefaultName(\ReflectionClass $class, \ReflectionMethod $method): string
+    {
+        $name = strtolower(str_replace('\\', '_', $class->name).'_'.$method->name);
+        if ($this->defaultRenderDefinitionIndex > 0) {
+            $name .= '_'.$this->defaultRenderDefinitionIndex;
+        }
+        ++$this->defaultRenderDefinitionIndex;
+
+        return preg_replace([
+            '/(bundle|controller)_/',
+            '/action(_\d+)?$/',
+            '/__/',
+        ], [
+            '_',
+            '\\1',
+            '_',
+        ], $name);
+    }
+}

--- a/ContentElement/RenderDefinition.php
+++ b/ContentElement/RenderDefinition.php
@@ -14,18 +14,15 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with the BartacusBundle.  If not, see <http://www.gnu.org/licenses/>.
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace Bartacus\Bundle\BartacusBundle\Annotation;
+namespace Bartacus\Bundle\BartacusBundle\ContentElement;
 
 /**
- * Define a Symfony controller actions as TYPO3 content element handler.
- *
- * @Annotation
- * @Target({"METHOD"})
+ * @author Patrik Karisch <p.karisch@pixelart.at>
  */
-final class ContentElement
+class RenderDefinition
 {
     /**
      * @var string
@@ -35,26 +32,29 @@ final class ContentElement
     /**
      * @var bool
      */
-    private $cached = true;
+    private $cached;
 
     /**
-     * @param array $options
+     * @var string
      */
-    public function __construct(array $options = [])
-    {
-        if (isset($options['value'])) {
-            $this->name = (string) $options['value'];
-        }
+    private $controller;
 
-        if (isset($options['cached'])) {
-            $this->cached = filter_var($options['cached'], FILTER_VALIDATE_BOOLEAN);
-        }
+    /**
+     * @param string $name
+     * @param bool   $cached
+     * @param string $controller
+     */
+    public function __construct($name, $cached, $controller)
+    {
+        $this->name = $name;
+        $this->cached = $cached;
+        $this->controller = $controller;
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -65,5 +65,13 @@ final class ContentElement
     public function isCached(): bool
     {
         return $this->cached;
+    }
+
+    /**
+     * @return string
+     */
+    public function getController(): string
+    {
+        return $this->controller;
     }
 }

--- a/ContentElement/RenderDefinitionCollection.php
+++ b/ContentElement/RenderDefinitionCollection.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types = 1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\ContentElement;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+/**
+ * @author Patrik Karisch <p.karisch@pixelart.at>
+ */
+class RenderDefinitionCollection implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var RenderDefinition[]
+     */
+    private $renderDefinitions = [];
+
+    /**
+     * @var array
+     */
+    private $resources = [];
+
+    /**
+     * Gets the current RouteCollection as an Iterator that includes all routes.
+     *
+     * It implements \IteratorAggregate.
+     *
+     * @see all()
+     *
+     * @return \ArrayIterator|RenderDefinition[] An \ArrayIterator object for iterating over routes
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->renderDefinitions);
+    }
+
+    /**
+     * Gets the number of Routes in this collection.
+     *
+     * @return int The number of routes
+     */
+    public function count(): int
+    {
+        return count($this->renderDefinitions);
+    }
+
+    /**
+     * @param RenderDefinition $renderDefinition
+     */
+    public function add(RenderDefinition $renderDefinition)
+    {
+        $this->renderDefinitions[] = $renderDefinition;
+    }
+
+    /**
+     * @return RenderDefinition[]
+     */
+    public function all(): array
+    {
+        return $this->renderDefinitions;
+    }
+
+    /**
+     * Returns an array of resources loaded to build this collection.
+     *
+     * @return ResourceInterface[] An array of resources
+     */
+    public function getResources(): array
+    {
+        return array_unique($this->resources);
+    }
+
+    /**
+     * Adds a resource for this collection.
+     *
+     * @param ResourceInterface $resource A resource instance
+     */
+    public function addResource(ResourceInterface $resource)
+    {
+        $this->resources[] = $resource;
+    }
+
+    /**
+     * Adds a render definition collection at the end of the current set by appending all
+     * render definitions of the added collection.
+     *
+     * @param RenderDefinitionCollection $collection
+     */
+    public function addCollection(RenderDefinitionCollection $collection)
+    {
+        $this->renderDefinitions = array_merge($this->renderDefinitions, $collection->all());
+        $this->resources = array_merge($this->resources, $collection->getResources());
+    }
+}

--- a/ContentElement/Renderer.php
+++ b/ContentElement/Renderer.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\ContentElement;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernel;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Dispatch a content element to controller action.
+ *
+ * @DI\Service("bartacus.content_element.renderer")
+ * @DI\Tag("bartacus.typoscript")
+ */
+class Renderer
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var HttpKernel
+     */
+    private $kernel;
+
+    /**
+     * @var RouterListener
+     */
+    private $routerListener;
+
+    /**
+     * @var ControllerResolverInterface
+     */
+    private $resolver;
+
+    /**
+     * Inject by the user function call from TYPO3 :/
+     *
+     * @var ContentObjectRenderer
+     */
+    public $cObj;
+
+    /**
+     * @DI\InjectParams(params={
+     *      "requestStack" = @DI\Inject("request_stack"),
+     *      "kernel" = @DI\Inject("http_kernel"),
+     *      "routerListener" = @DI\Inject("router_listener"),
+     *      "resolver" = @DI\Inject("controller_resolver"),
+     * })
+     */
+    public function __construct(RequestStack $requestStack, HttpKernel $kernel, RouterListener $routerListener, ControllerResolverInterface $resolver)
+    {
+        $this->requestStack = $requestStack;
+        $this->kernel = $kernel;
+        $this->routerListener = $routerListener;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * @param string                $content       The content. Not used
+     * @param array                 $configuration The TS configuration array
+     *
+     * @return string $content The processed content
+     */
+    public function handle(string $content, array $configuration): string
+    {
+        $request = Request::createFromGlobals();
+
+        $request->attributes->set('data', $this->cObj->data);
+        $request->attributes->set('_controller', $configuration['controller']);
+
+        $request->headers->set('X-Php-Ob-Level', ob_get_level());
+        $this->requestStack->push($request);
+
+        $event = new GetResponseEvent(
+            $this->kernel,
+            $request,
+            HttpKernel::SUB_REQUEST
+        );
+        $this->routerListener->onKernelRequest($event);
+
+        // load controller
+        $controller = $this->resolver->getController($request);
+        if (false === $controller) {
+            throw new NotFoundHttpException(
+                sprintf(
+                    'Unable to find the controller "%s". The content element is wrongly configured.',
+                    $request->attributes->get('_controller', $configuration['controller'])
+                )
+            );
+        }
+
+        // controller arguments
+        $arguments = $this->resolver->getArguments($request, $controller);
+
+        // call controller
+        $response = call_user_func_array($controller, $arguments);
+
+        // view
+        if (!$response instanceof Response) {
+            $msg = sprintf(
+                'The controller must return a response (%s given).',
+                $this->varToString($response)
+            );
+
+            // the user may have forgotten to return something
+            if (null === $response) {
+                $msg .= ' Did you forget to add a return statement somewhere in your controller?';
+            }
+            throw new \LogicException($msg);
+        }
+
+        $this->routerListener->onKernelFinishRequest(
+            new FinishRequestEvent(
+                $this->kernel,
+                $request,
+                HttpKernel::SUB_REQUEST
+            )
+        );
+        $this->requestStack->pop();
+
+        if ($response instanceof RedirectResponse) {
+            $response->send();
+            $this->kernel->terminate($request, $response);
+            exit();
+        }
+
+        if (count($response->headers) || $response->getStatusCode() !== 200) {
+            $response->sendHeaders();
+        }
+
+        return $response->getContent();
+    }
+
+    /**
+     * @param $var
+     *
+     * @return string
+     */
+    private function varToString($var): string
+    {
+        if (is_object($var)) {
+            return sprintf('Object(%s)', get_class($var));
+        }
+
+        if (is_array($var)) {
+            $a = [];
+            foreach ($var as $k => $v) {
+                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
+            }
+
+            return sprintf('Array(%s)', implode(', ', $a));
+        }
+
+        if (is_resource($var)) {
+            return sprintf('Resource(%s)', get_resource_type($var));
+        }
+
+        if (null === $var) {
+            return 'null';
+        }
+
+        if (false === $var) {
+            return 'false';
+        }
+
+        if (true === $var) {
+            return 'true';
+        }
+
+        return (string) $var;
+    }
+}

--- a/Resources/doc/content_elements.rst
+++ b/Resources/doc/content_elements.rst
@@ -1,0 +1,104 @@
+.. _content:
+
+================
+Content Elements
+================
+
+With Bartacus you are able to dispatch content elements to Symfony controller
+actions. This creates a harmony with the ability to dispatch routes directly to
+Symfony and not to TYPO3.
+
+Configuration
+=============
+
+To dispatch content elements to Symfony, you have to define a ``@ContentElement``
+annotation on your action method. Same like a Symfony ``@Route`` annotation.
+
+The data which is usually retrieved via ``$this->cObj->data`` in old pi_base
+plugin is now injected into the ``$data`` parameter of the method if it exists.
+
+.. code-block:: php
+
+    <?php declare(strict_types=1);
+    // src/AppBundle/Controller/ContentController.php
+
+    namespace AppBundle\Controller;
+
+    use Bartacus\Bundle\BartacusBundle\Annotation\ContentElement;
+    use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Component\HttpFoundation\Response;
+
+    class ContentController extends Controller
+    {
+        /**
+         * @ContentElement("content_text")
+         */
+        public function textAction(array $data): Response
+        {
+            // ..
+
+            return $this->render('content/text.html.twig', [
+                // ..
+            ]);
+        }
+    }
+
+To have the plugin not cached, add the ``cached=false attribute into the
+annotation, e.g: ``@ContentElement("form_contact", cached=false)``
+
+Configuration of the TCA for inserting the content element in the backend and
+available fields MUST be done in ``Configuration/TCA`` and
+``Configuration/TCA/Overrides`` as usual.
+(TODO: Use models and annotations too)
+
+.. note::
+
+    Bartacus mocks the Symfony http foundation kernel requests, which means you
+    have access to the ``Request`` instance as a sub request as seen above and
+    must return a ``Response`` instance, but none of the usual kernel events are
+    dispatched.
+
+Reusable bundles
+================
+
+If you create a reusable bundle, make sure you register the bundle for the
+jms_di_extra config in your prepend extension:
+
+.. code-block:: php
+
+    <?php declare(strict_types=1);
+
+    namespace Acme\Bundle\MyBundle\DependencyInjection;
+
+    use Bartacus\Bundle\BartacusBundle\Exception\DependencyUnsatisfiedException;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
+    use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+    use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+    /**
+     * Handle registration with JMSDiExtraBundle and other stuff.
+     */
+    class BartacusExtension extends Extension implements PrependExtensionInterface
+    {
+        public function load(array $configs, ContainerBuilder $container)
+        {
+            // Nothing to load atm.
+        }
+
+        public function prepend(ContainerBuilder $container)
+        {
+            $bundles = $container->getParameter('kernel.bundles');
+            if (!isset($bundles['JMSDiExtraBundle'])) {
+                throw new DependencyUnsatisfiedException('The JMSDiExtraBundle is not loaded!');
+            }
+
+            $container->prependExtensionConfig('jms_di_extra', [
+                'locations' => [
+                    'bundles' => [
+                        'AcmeMyBundle',
+                    ],
+                ],
+            ]);
+        }
+    }

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -22,3 +22,4 @@ Contents
 
     getting-started/index
     services_typoscript
+    content_elements


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #4, fixes #5 
| Related issues/PRs | connects to #6 
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Add the possibility to render content elements with symonfy controller actions, configured by annotations.

Redirect response as asked in #5 are already included from migrating old code base.

Handling 404 response as asked in #6 is only partially included. 404 status code is sent, but the controller action is responsible for generating an output for the moment.