### PR TITLE
Add service bridge for common TYPO3 functionality 

### DIFF
--- a/CacheWarmer/ControllerInjectorsWarmer.php
+++ b/CacheWarmer/ControllerInjectorsWarmer.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\CacheWarmer;
+
+use JMS\DiExtraBundle\HttpKernel\ControllerResolver;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ControllerInjectorsWarmer implements CacheWarmerInterface
+{
+    private $kernel;
+
+    private $controllerResolver;
+
+    private $blackListedControllerFiles;
+
+    public function __construct(KernelInterface $kernel, ControllerResolver $resolver, array $blackListedControllerFiles)
+    {
+        $this->kernel = $kernel;
+        $this->controllerResolver = $resolver;
+        $this->blackListedControllerFiles = $blackListedControllerFiles;
+    }
+
+    public function warmUp($cacheDir)
+    {
+        // This avoids class-being-declared twice errors when the cache:clear
+        // command is called. The controllers are not pre-generated in that case.
+        $suffix = defined('Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate::NEW_CACHE_FOLDER_SUFFIX')
+            ? CacheWarmerAggregate::NEW_CACHE_FOLDER_SUFFIX
+            : '_new';
+
+        if (basename($cacheDir) === $this->kernel->getEnvironment().$suffix) {
+            return;
+        }
+
+        $classes = $this->findControllerClasses();
+        foreach ($classes as $class) {
+            $this->controllerResolver->createInjector($class);
+        }
+    }
+
+    public function isOptional()
+    {
+        return false;
+    }
+
+    private function findControllerClasses()
+    {
+        $dirs = [];
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if (!is_dir($controllerDir = $bundle->getPath().'/Controller')) {
+                continue;
+            }
+
+            $dirs[] = $controllerDir;
+        }
+
+        foreach (Finder::create()->name('*Controller.php')->in($dirs)->files() as $file) {
+            $filename = $file->getRealPath();
+            if (!in_array($filename, $this->blackListedControllerFiles, true)) {
+                require_once $filename;
+            }
+        }
+
+        // It is not so important if these controllers never can be reached with
+        // the current configuration nor whether they are actually controllers.
+        // Important is only that we do not miss any classes.
+        return array_filter(get_declared_classes(), function ($name) {
+            return preg_match('/(?<!TYPO3\\\CMS\\\Frontend\\\)Controller\\\(.+)Controller$/', $name) > 0;
+        });
+    }
+}

--- a/DependencyInjection/BartacusExtension.php
+++ b/DependencyInjection/BartacusExtension.php
@@ -40,6 +40,7 @@ class BartacusExtension extends Extension implements PrependExtensionInterface
         );
 
         $loader->load('typo3.xml');
+        $loader->load('overrides.xml');
     }
 
     public function prepend(ContainerBuilder $container)

--- a/DependencyInjection/BartacusExtension.php
+++ b/DependencyInjection/BartacusExtension.php
@@ -20,9 +20,12 @@
 namespace Bartacus\Bundle\BartacusBundle\DependencyInjection;
 
 use Bartacus\Bundle\BartacusBundle\Exception\DependencyUnsatisfiedException;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Handle registration with JMSDiExtraBundle and other stuff.
@@ -31,7 +34,12 @@ class BartacusExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        // TODO: Nothing to load atm.
+        $loader = new XmlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+
+        $loader->load('typo3.xml');
     }
 
     public function prepend(ContainerBuilder $container)

--- a/Resources/config/overrides.xml
+++ b/Resources/config/overrides.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+  ~ This file is part of the BartacusBundle.
+  ~
+  ~ The BartacusBundle is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ The BartacusBundle is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="jms_di_extra.controller_injectors_warmer" class="Bartacus\Bundle\BartacusBundle\CacheWarmer\ControllerInjectorsWarmer" public="false">
+            <tag name="kernel.cache_warmer" />
+            <argument type="service" id="kernel" />
+            <argument type="service" id="jms_di_extra.controller_resolver" />
+            <argument>%jms_di_extra.cache_warmer.controller_file_blacklist%</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/typo3.xml
+++ b/Resources/config/typo3.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+  ~ This file is part of the BartacusBundle.
+  ~
+  ~ The BartacusBundle is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ The BartacusBundle is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="typo3" class="Bartacus\Bundle\BartacusBundle\Typo3\ServiceBridge" />
+
+        <service id="typo3.backend_user" class="TYPO3\CMS\Core\Authentication\BackendUserAuthentication">
+            <factory service="typo3" method="getGlobal" />
+            <argument>BE_USER</argument>
+        </service>
+
+        <service id="typo3.frontend_user" class="TYPO3\CMS\Core\Authentication\FrontendUserAuthentication">
+            <factory service="typo3" method="getGlobal" />
+            <argument>FE_USER</argument>
+        </service>
+
+        <service id="typo3.cache.cache_manager" class="TYPO3\CMS\Core\Cache\CacheManager" shared="false">
+            <factory service="typo3" method="makeInstance" />
+            <argument>TYPO3\CMS\Core\Cache\CacheManager</argument>
+        </service>
+        <service id="typo3.cache.cache_hash" class="TYPO3\CMS\Core\Cache\Frontend\FrontendInterface">
+            <factory service="typo3.cache.cache_manager" method="getCache" />
+            <argument>cache_hash</argument>
+        </service>
+        <service id="typo3.cache.cache_pages" class="TYPO3\CMS\Core\Cache\Frontend\FrontendInterface">
+            <factory service="typo3.cache.cache_manager" method="getCache" />
+            <argument>cache_pages</argument>
+        </service>
+        <service id="typo3.cache.cache_pagesection" class="TYPO3\CMS\Core\Cache\Frontend\FrontendInterface">
+            <factory service="typo3.cache.cache_manager" method="getCache" />
+            <argument>cache_pagesection</argument>
+        </service>
+        <service id="typo3.cache.cache_rootline" class="TYPO3\CMS\Core\Cache\Frontend\FrontendInterface">
+            <factory service="typo3.cache.cache_manager" method="getCache" />
+            <argument>cache_rootline</argument>
+        </service>
+
+        <service id="typo3.cache_hash_calculator" class="TYPO3\CMS\Frontend\Page\CacheHashCalculator" shared="false">
+            <factory service="typo3" method="makeInstance" />
+            <argument>TYPO3\CMS\Frontend\Page\CacheHashCalculator</argument>
+        </service>
+
+        <service id="typo3.content_object_renderer" class="TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer">
+            <factory service="typo3" method="getContentObjectRenderer" />
+        </service>
+
+        <service id="typo3.db" class="TYPO3\CMS\Core\Database\DatabaseConnection" lazy="true">
+            <factory service="typo3" method="getGlobal" />
+            <argument>TYPO3_DB</argument>
+        </service>
+
+        <service id="typo3.file_repository" class="TYPO3\CMS\Core\Resource\FileRepository" shared="false">
+            <factory service="typo3" method="makeInstance" />
+            <argument>TYPO3\CMS\Core\Resource\FileRepository</argument>
+        </service>
+
+        <service id="typo3.frontend_controller" class="TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController">
+            <factory service="typo3" method="getGlobal" />
+            <argument>TSFE</argument>
+        </service>
+
+        <service id="typo3.page_repository" class="TYPO3\CMS\Frontend\Page\PageRepository">
+            <factory service="typo3" method="getPageRepository" />
+        </service>
+    </services>
+</container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,3 +23,4 @@ Contents
     getting-started/index
     services_typoscript
     content_elements
+    service_bridge

--- a/Resources/doc/service_bridge.rst
+++ b/Resources/doc/service_bridge.rst
@@ -1,0 +1,81 @@
+=====================
+TYPO3 bridge services
+=====================
+
+The common TYPO3 classes are available in the service container for you:
+
+The ``TYPO3\CMS\Core\Cache\CacheManager`` is available as
+``typo3.cache.cache_manager`` and the common caches can be retrieved via
+``typo3.cache.cache_hash``, ``typo3.cache.cache_pages``,
+``typo3.cache.cache_pagesection`` and ``typo3.cache.cache_rootline``.
+
+The ``TSFE`` is available as ``typo3.frontend_controller``, the ``sys_page`` on
+the TSFE as ``typo3.page_repository`` and the ``cObj`` on the TSFE as
+``typo3.content_object_renderer`` service.
+
+The ``TYPO3_DB`` is available as ``typo3.db`` service.
+
+The ``BE_USER`` is available as ``typo3.backend_user`` service. This service
+may be ``null`` if no backend user is logged in.
+
+The ``FE_USER`` is available as ``typo3.frontend_user`` service. This service
+may be ``null`` if no frontend user is logged in.
+
+The ``TYPO3\CMS\Core\Resource\FileRepository`` for the FAL is available as
+``typo3.file_repository``.
+
+The ``TYPO3\CMS\Frontend\Page\CacheHashCalculator`` is available as
+``typo3.cache_hash_calculator`` service.
+
+Globals and ``makeInstace``
+===========================
+
+Although you have a common set of services available above, sometimes you need
+access to some of the other TYPO3 globals or retrieve other TYPO3 classes with
+``GeneralUtility::makeInstance()``. This will clutter your code and is really
+bad as it makes your services not testable.
+
+Instead you can create services from TYPO3 globals with the factory pattern:
+
+.. code-block:: yaml
+
+    services:
+        app.typo3.language:
+            class: TYPO3\CMS\Lang\LanguageService
+            factory: ["@typo3", getGlobal]
+            arguments:
+                - LANG
+
+The same it possible with classes from ``GeneralUtility::makeInstance()``, but
+the must be set shared to false, so ``makeInstance()`` is still in control
+whether you get the same instance or a new one every time you inject the
+service.
+
+.. code-block:: yaml
+
+    services:
+        app.typo3.template_service:
+            class: TYPO3\CMS\Core\TypoScript\TemplateService
+            shared: false
+            factory: ["@typo3", makeInstance]
+            arguments:
+                - "TYPO3\\CMS\\Core\\TypoScript\\TemplateService"
+
+
+Other caches as service
+=======================
+
+If you have defined your own cache in your extension, make it available to the
+service container to. It's the same as getting a global from TYPO3, but instead
+you are using the cache manager as a factory.
+
+The configured cache in this example is ``acme_geocoding``:
+
+.. code-block:: yaml
+
+    services:
+        app.cache.acme_geocoding:
+            class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
+            factory: ["@typo3.cache.cache_manager", getCache]
+            arguments:
+                - acme_geocoding

--- a/Typo3/ServiceBridge.php
+++ b/Typo3/ServiceBridge.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Typo3;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
+/**
+ * Service bridge to TYPO3 instantiation and global instances.
+ *
+ * @author Patrik Karisch <p.karisch@pixelart.at>
+ */
+class ServiceBridge
+{
+    /**
+     * Wrapper around {@see GeneralUtility::makeInstance()}.
+     *
+     * @param string $className
+     *
+     * @return object
+     */
+    public function makeInstance(string $className)
+    {
+        return GeneralUtility::makeInstance($className);
+    }
+
+    /**
+     * Get a TYPO3 global into the service container.
+     *
+     * @param string $global
+     *
+     * @return mixed
+     */
+    public function getGlobal(string $global)
+    {
+        return $GLOBALS[$global];
+    }
+
+    /**
+     * @return ContentObjectRenderer
+     */
+    public function getContentObjectRenderer(): ContentObjectRenderer
+    {
+        return $this->getGlobal('TSFE')->cObj;
+    }
+
+    /**
+     * @return PageRepository
+     */
+    public function getPageRepository(): PageRepository
+    {
+        return $this->getGlobal('TSFE')->sys_page;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #30
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Add service bridge for common TYPO3 functionality and services.


### Caveats

Had to override the controller injector cache warmer from jms di extra, because it wanted to analyse all Controller classes and the TSFE matched the regex. But the TSFE includes non phpdoc annotations and thus the cache warmer failed.