### PR TITLE
Catch a 404 http exception and handle it with TYPO3

### DIFF
--- a/Resources/doc/content_elements.rst
+++ b/Resources/doc/content_elements.rst
@@ -66,6 +66,17 @@ You are able to use redirect responses in a content element action too.
 Bartacus detects the ``RedirectResponse`` instance and sends the redirect
 headers, terminates the kernel and exits. No further TYPO3 code is executed.
 
+404 responses
+-------------
+
+You have two options how you can handle 404 responses. Either you throw a not
+found exception with ``throw $this->createNotFoundException();`` and TYPO3 will
+take care of it with the configure page not found handler.
+
+Or if you want to show a special content if nothing is found, but still need a
+404 status code for SEO reasons, render your special content and return a normal
+response object with the status code set to 404.
+
 Reusable bundles
 ================
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #6 
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Handles a not found exception from a content element controller action gracefully with the TYPO3 page not found handler.