### PR TITLE
Override php bridge session storage

### DIFF
--- a/Resources/config/overrides.xml
+++ b/Resources/config/overrides.xml
@@ -28,5 +28,11 @@
             <argument type="service" id="jms_di_extra.controller_resolver" />
             <argument>%jms_di_extra.cache_warmer.controller_file_blacklist%</argument>
         </service>
+
+        <service id="session.storage.php_bridge" class="Bartacus\Bundle\BartacusBundle\Session\Storage\PhpBridgeSessionStorage">
+            <argument>%session.storage.options%</argument>
+            <argument type="service" id="session.handler" />
+            <argument type="service" id="session.storage.metadata_bag" />
+        </service>
     </services>
 </container>

--- a/Session/Storage/PhpBridgeSessionStorage.php
+++ b/Session/Storage/PhpBridgeSessionStorage.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
+
+/**
+ * Allows session to be started either by PHP or by Symfony and managed by Symfony.
+ */
+class PhpBridgeSessionStorage extends NativeSessionStorage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+        if ($this->started) {
+            return true;
+        }
+
+        $shouldStart = true;
+        if (\PHP_SESSION_ACTIVE === session_status()) {
+            $shouldStart = false;
+        }
+
+        if (ini_get('session.use_cookies') && headers_sent($file, $line)) {
+            throw new \RuntimeException(sprintf('Failed to start the session because headers have already been sent by "%s" at line %d.', $file, $line));
+        }
+
+        // ok to try and start the session
+        if ($shouldStart && !session_start()) {
+            throw new \RuntimeException('Failed to start the session');
+        }
+
+        $this->loadSession();
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        // clear out the bags and nothing else that may be set
+        // since the purpose of this driver is to share a handler
+        foreach ($this->bags as $bag) {
+            $bag->clear();
+
+            $key = $bag->getStorageKey();
+            $_SESSION[$key] = [];
+        }
+
+        // reconnect the bags to the session
+        $this->loadSession();
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #32
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Override php bridge session storage, so it can be started by TYPO3 (extensions) and Symfony. Probably TYPO3 started extension will send wrong cache headers...
