### PR TITLE
Set the correct locale on the request

### DIFF
--- a/Resources/doc/getting-started/index.rst
+++ b/Resources/doc/getting-started/index.rst
@@ -7,3 +7,4 @@ Getting started
     :maxdepth: 2
 
     installation
+    locale

--- a/Resources/doc/getting-started/locale.rst
+++ b/Resources/doc/getting-started/locale.rst
@@ -1,0 +1,37 @@
+===============
+Locale handling
+===============
+
+The locale handling with Bartacus differs a little bit from the default you are
+used to in Symfony.
+
+Frontend
+========
+
+The locale on the request is set from the TSFE locale context on the domain you
+are on. It uses the ``sys_language_isocode`` which is automatically derived by
+TYPO3 from your ``sys_language`` settings in the backend. Optionally you can
+override this field in your TypoScript config.
+
+Content elements
+----------------
+
+As a result, using the translator in a content element gets always the correct
+language the frontend expects.
+
+Symfony routes
+--------------
+
+You must set the correct TSFE ``sys_language_uid`` by always adding the ``?L=x``
+query parameter to your routes! Adding the ``L`` parameter is important to
+initialize the correct TSFE instance, e.g. for getting the correct translated
+database records.
+
+Additionally it's still possible to encode ``{_locale}`` in your route, which
+overwrites the locale from the TSFE for the translator component.
+
+Backend / TYPO3 CLI
+===================
+
+Since there is no TSFE or symfony request handled, the translator uses the
+default locale, configured in your ``config.yml``.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #17 
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Set the correct locale on the request from the configured locale (isocode) in the typoscript on the page. Which means the locale depends on the `L=?` parameter. Its practical for content element requests, because the translator is already configured.
