### PR TITLE
Remove security advisories, you can't always force users to use it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "symfony/symfony": "^3.0",
         "symfony/psr-http-message-bridge": "^1.0",
         "jms/di-extra-bundle": "^1.8",
-        "ocramius/proxy-manager": "^2.0",
-        "roave/security-advisories": "dev-master"
+        "ocramius/proxy-manager": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | reverts #24
| License | GPL-3.0+

#### What's in this PR?

Remove security advisories, you can't always force users to use it. Like in the current case I must fallback to TYPO3 8.3.0 to install helhum/typo3-console...
