### PR TITLE
Fix empty cookie params to not be null

### DIFF
--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -498,6 +498,14 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
             $refQueryParams->setValue($request, []);
         }
 
+        $refCookieParams = $refObj->getProperty('cookieParams');
+        $refCookieParams->setAccessible(true);
+
+        $cookies = $refCookieParams->getValue($request);
+        if (null === $cookies) {
+            $refCookieParams->setValue($request, []);
+        }
+
         $refAttributes = $refObj->getProperty('attributes');
         $refAttributes->setAccessible(true);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #45 
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Fix empty `cookieParams` ont the TYPO3 server request, which is null and not an empty array if no cookies are sent from the client.
