### PR TITLE
Reuse the request from the request stack

### DIFF
--- a/ContentElement/Renderer.php
+++ b/ContentElement/Renderer.php
@@ -99,13 +99,12 @@ class Renderer
      */
     public function handle(string $content, array $configuration): string
     {
-        $request = Request::createFromGlobals();
+        $request = $this->requestStack->getCurrentRequest();
 
         $request->attributes->set('data', $this->cObj->data);
         $request->attributes->set('_controller', $configuration['controller']);
 
         $request->headers->set('X-Php-Ob-Level', ob_get_level());
-        $this->requestStack->push($request);
 
         $event = new GetResponseEvent(
             $this->kernel,
@@ -156,7 +155,9 @@ class Renderer
                 HttpKernel::SUB_REQUEST
             )
         );
-        $this->requestStack->pop();
+
+        $request->attributes->remove('data');
+        $request->attributes->remove('_controller');
 
         if ($response instanceof RedirectResponse) {
             $response->send();


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #17 
| Related issues/PRs | #37
| License | GPL-3.0+

#### What's in this PR?

Reuse the request from the request stack in content element renderer. No need to create a new request from globals, which then differentiates from the main request handled. Maybe clone a sub request in the future
