### PR TITLE
Let TYPO3 prepare the web dir and overwrite entry scripts

### DIFF
--- a/DependencyInjection/BartacusExtension.php
+++ b/DependencyInjection/BartacusExtension.php
@@ -46,7 +46,6 @@ class BartacusExtension extends Extension implements PrependExtensionInterface
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('bartacus.paths.vendor_dir', $config['paths']['vendor_dir']);
         $container->setParameter('bartacus.paths.web_dir', $config['paths']['web_dir']);
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,7 +36,6 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('paths')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('vendor_dir')->defaultValue('%kernel.root_dir%/../vendor')->end()
                         ->scalarNode('web_dir')->defaultValue('%kernel.root_dir%/../web')->end()
                     ->end()
                 ->end() // paths

--- a/Resources/scripts/backend.php
+++ b/Resources/scripts/backend.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Backend\Http\Application;
+
+$bartacusScripts = __DIR__.'/../../../../../../../../../vendor/bartacus/bartacus-bundle/Resources/scripts';
+
+list($loader, $kernel) = require $bartacusScripts.'/kernel.php';
+$application = new Application($loader);
+require $bartacusScripts.'/package.php';
+$application->run();

--- a/Resources/scripts/cli.php
+++ b/Resources/scripts/cli.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Backend\Console\Application;
+
+$bartacusScripts = __DIR__.'/../../../../../../../../../vendor/bartacus/bartacus-bundle/Resources/scripts';
+
+list($loader, $kernel) = require $bartacusScripts.'/kernel.php';
+$application = new Application($loader);
+require $bartacusScripts.'/package.php';
+$application->run();

--- a/Resources/scripts/index.php
+++ b/Resources/scripts/index.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use Bartacus\Bundle\BartacusBundle\Http\FrontendApplication;
+
+$bartacusScripts = __DIR__.'/../../../vendor/bartacus/bartacus-bundle/Resources/scripts';
+
+list($loader, $kernel) = require $bartacusScripts.'/kernel.php';
+$application = new FrontendApplication($loader, $kernel);
+require $bartacusScripts.'/package.php';
+$application->run();

--- a/Resources/scripts/kernel.php
+++ b/Resources/scripts/kernel.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Debug\Debug;
+
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'prod');
+defined('SYMFONY_DEBUG') || define(
+    'SYMFONY_DEBUG',
+    filter_var(getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev', FILTER_VALIDATE_BOOLEAN)
+);
+
+/** @var \Composer\Autoload\ClassLoader $loader */
+$loader = require __DIR__.'/../../../../../vendor/autoload.php';
+include_once __DIR__.'/../../../../../var/bootstrap.php.cache';
+
+if (SYMFONY_DEBUG) {
+    Debug::enable();
+}
+
+$kernel = new AppKernel(SYMFONY_ENV, SYMFONY_DEBUG);
+$kernel->boot();
+
+return [$loader, $kernel];

--- a/Resources/scripts/package.php
+++ b/Resources/scripts/package.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the BartacusBundle.
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Compatibility\LoadedExtensionArrayElement;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Package\Package;
+use TYPO3\CMS\Core\Package\PackageManager;
+
+/** @var PackageManager $packageManager */
+$packageManager = Bootstrap::getInstance()->getEarlyInstance(PackageManager::class);
+$package = new Package($packageManager, 'app', rtrim(realpath(__DIR__.'/../../../../../app/'), '\\/').'/');
+$packageManager->registerPackage($package);
+
+Closure::bind(function (PackageManager $instance) use ($package) {
+    $instance->runtimeActivatedPackages[$package->getPackageKey()] = $package;
+}, $packageManager, PackageManager::class)->__invoke($packageManager);
+
+if (!isset($GLOBALS['TYPO3_LOADED_EXT'][$package->getPackageKey()])) {
+    $loadedExtArrayElement = new LoadedExtensionArrayElement($package);
+    Closure::bind(function (LoadedExtensionArrayElement $instance) {
+        $instance->extensionInformation['type'] = 'L';
+    }, $loadedExtArrayElement, LoadedExtensionArrayElement::class)->__invoke($loadedExtArrayElement);
+
+    $GLOBALS['TYPO3_LOADED_EXT'][$package->getPackageKey()] = $loadedExtArrayElement->toArray();
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | connects to #51 
| License | GPL-3.0+

#### What's in this PR?

Let TYPO3 prepare the web dir and overwrite entry scripts. This uses the stability of the cms-installer for the symlink handling instead of doing itself.

If the path resolution to the bartacus dir works on windows too, when used on windows w/o symlinks.. I doubt it..

