### PR TITLE
RealUrl support

### DIFF
--- a/Http/Factory/Typo3PsrMessageFactory.php
+++ b/Http/Factory/Typo3PsrMessageFactory.php
@@ -48,7 +48,7 @@ class Typo3PsrMessageFactory implements HttpMessageFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createResponse(Response $symfonyResponse):ResponseInterface
+    public function createResponse(Response $symfonyResponse): ResponseInterface
     {
         if ($symfonyResponse instanceof BinaryFileResponse) {
             $stream = new Typo3Stream($symfonyResponse->getFile()->getPathname(), 'r');


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | connects to Bartacus/Bartacus-Standard#13
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Checking if the actual route matches a symfony one. Otherwise realurl checks it as speaking path. Although no symfony route is found, the whole kernel is still executed after, so all the stuff is correctly initialized.
