### PR TITLE
Recreate request objects after globals change

### DIFF
--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -198,6 +198,8 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
 
         if ($handleWithRealUrl) {
             $this->controller->checkAlternativeIdMethods();
+            $request = ServerRequestFactory::fromGlobals();
+            $symfonyRequest = $httpFoundationFactory->createRequest($request);
         }
         $this->controller->clear_preview();
         $this->controller->determineId();


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | - 
| Related issues/PRs | -  
| Bugfix | yes
| License | GPL-3.0+


#### What's in this PR?

The request objects for typo3 and symfony are created again after globals have possibly been changed in checkAlternativeMehod hook, so the request has the get paramters resolved by realurl or cooluri
