### PR TITLE
Update to TYPO3 8.6

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,15 +21,15 @@
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-declare(strict_types=1);
-
-$finder = Symfony\CS\Finder::create()
+$finder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->in(__DIR__)
 ;
 
-$header = <<<EOF
-This file is part of the BartacusBundle.
+$header = <<<'EOF'
+This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+
+Copyright (c) 2016-2017 Patrik Karisch
 
 The BartacusBundle is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -41,24 +45,28 @@ You should have received a copy of the GNU General Public License
 along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
 EOF;
 
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
-
-return Symfony\CS\Config::create()
-    ->fixers([
-        'combine_consecutive_unsets',
-        'header_comment',
-        'no_useless_else',
-        'no_useless_return',
-        'ordered_use',
-        'php_unit_construct',
-        'php_unit_dedicate_assert',
-        'php_unit_strict',
-        'phpdoc_order',
-        'short_array_syntax',
-        'silenced_deprecation_error',
-        'strict',
-        'strict_param',
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'combine_consecutive_unsets' => true,
+        'declare_strict_types' => true,
+        'dir_constant' => true,
+        'header_comment' => ['header' => $header],
+        'heredoc_to_nowdoc' => true,
+        'linebreak_after_opening_tag' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'phpdoc_order' => true,
+        'simplified_null_return' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'ternary_to_null_coalescing' => true,
     ])
-    ->finder($finder)
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
     ->setUsingCache(true)
 ;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,13 +2,17 @@ preset: symfony
 
 enabled:
     - combine_consecutive_unsets
+    - declare_strict_types
+    - dir_constant
+    - linebreak_after_opening_tag
+    - no_unreachable_default_argument_value
     - no_useless_else
     - no_useless_return
-    - ordered_use
+    - ordered_imports
     - php_unit_construct
     - php_unit_dedicate_assert
     - php_unit_strict
     - phpdoc_order
     - short_array_syntax
-    - strict
+    - strict_comparison
     - strict_param

--- a/Annotation/ContentElement.php
+++ b/Annotation/ContentElement.php
@@ -39,9 +39,6 @@ final class ContentElement
      */
     private $cached = true;
 
-    /**
-     * @param array $options
-     */
     public function __construct(array $options = [])
     {
         if (isset($options['value'])) {
@@ -53,17 +50,11 @@ final class ContentElement
         }
     }
 
-    /**
-     * @return string|null
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    /**
-     * @return bool
-     */
     public function isCached(): bool
     {
         return $this->cached;

--- a/Annotation/ContentElement.php
+++ b/Annotation/ContentElement.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Annotation;
 

--- a/BartacusBundle.php
+++ b/BartacusBundle.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle;
 

--- a/CacheWarmer/ContentElementCacheWarmer.php
+++ b/CacheWarmer/ContentElementCacheWarmer.php
@@ -49,7 +49,7 @@ class ContentElementCacheWarmer implements CacheWarmerInterface
      *
      * @param string $cacheDir The cache directory
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): void
     {
         if ($this->configLoader instanceof WarmableInterface) {
             $this->configLoader->warmUp($cacheDir);
@@ -61,7 +61,7 @@ class ContentElementCacheWarmer implements CacheWarmerInterface
      *
      * @return bool always true
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }

--- a/CacheWarmer/ContentElementCacheWarmer.php
+++ b/CacheWarmer/ContentElementCacheWarmer.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\CacheWarmer;
 

--- a/CacheWarmer/ControllerInjectorsWarmer.php
+++ b/CacheWarmer/ControllerInjectorsWarmer.php
@@ -42,7 +42,7 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
         $this->blackListedControllerFiles = $blackListedControllerFiles;
     }
 
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): void
     {
         // This avoids class-being-declared twice errors when the cache:clear
         // command is called. The controllers are not pre-generated in that case.
@@ -60,12 +60,12 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
         }
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return false;
     }
 
-    private function findControllerClasses()
+    private function findControllerClasses(): array
     {
         $dirs = [];
         foreach ($this->kernel->getBundles() as $bundle) {
@@ -86,7 +86,7 @@ class ControllerInjectorsWarmer implements CacheWarmerInterface
         // It is not so important if these controllers never can be reached with
         // the current configuration nor whether they are actually controllers.
         // Important is only that we do not miss any classes.
-        return array_filter(get_declared_classes(), function ($name) {
+        return array_filter(get_declared_classes(), function (string $name) {
             return preg_match('/(?<!TYPO3\\\CMS\\\Frontend\\\)Controller\\\(.+)Controller$/', $name) > 0;
         });
     }

--- a/CacheWarmer/ControllerInjectorsWarmer.php
+++ b/CacheWarmer/ControllerInjectorsWarmer.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\CacheWarmer;
 

--- a/Command/PrepareWebDirCommand.php
+++ b/Command/PrepareWebDirCommand.php
@@ -57,7 +57,7 @@ class PrepareWebDirCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this
             ->setName('bartacus:web-dir:prepare')
@@ -65,7 +65,7 @@ class PrepareWebDirCommand extends Command
         ;
     }
 
-    public function run(InputInterface $input, OutputInterface $output)
+    public function run(InputInterface $input, OutputInterface $output): void
     {
         $this->filesystem->copy(
             __DIR__.'/../Resources/scripts/index.php',

--- a/Command/PrepareWebDirCommand.php
+++ b/Command/PrepareWebDirCommand.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Command;
 

--- a/Config/ConfigLoader.php
+++ b/Config/ConfigLoader.php
@@ -49,7 +49,7 @@ class ConfigLoader
         $this->contentElement = $contentElement;
     }
 
-    public function loadFromAdditionalConfiguration()
+    public function loadFromAdditionalConfiguration(): void
     {
         $this->contentElement->load();
     }

--- a/Config/ConfigLoader.php
+++ b/Config/ConfigLoader.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Config;
 

--- a/ContentElement/ContentElementConfigLoader.php
+++ b/ContentElement/ContentElementConfigLoader.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\ContentElement;
 

--- a/ContentElement/Loader/AnnotationBundleLoader.php
+++ b/ContentElement/Loader/AnnotationBundleLoader.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +21,6 @@
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-declare(strict_types=1);
-
 namespace Bartacus\Bundle\BartacusBundle\ContentElement\Loader;
 
 use Bartacus\Bundle\BartacusBundle\ContentElement\RenderDefinitionCollection;
@@ -26,7 +28,6 @@ use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Resource\DirectoryResource;
-use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @DI\Service("bartacus.content_element.loader")

--- a/ContentElement/Loader/AnnotationBundleLoader.php
+++ b/ContentElement/Loader/AnnotationBundleLoader.php
@@ -26,6 +26,7 @@ use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @DI\Service("bartacus.content_element.loader")
@@ -93,7 +94,7 @@ class AnnotationBundleLoader extends FileLoader
                     continue;
                 }
 
-                $class = $this->findClass($file);
+                $class = $this->findClass((string) $file);
                 if ($class) {
                     $refl = new \ReflectionClass($class);
                     if ($refl->isAbstract()) {
@@ -132,11 +133,11 @@ class AnnotationBundleLoader extends FileLoader
      *
      * @return string|false Full class name if found, false otherwise
      */
-    protected function findClass($file)
+    protected function findClass(string $file)
     {
         $class = false;
         $namespace = false;
-        $tokens = token_get_all(file_get_contents((string) $file));
+        $tokens = token_get_all(file_get_contents($file));
         for ($i = 0; isset($tokens[$i]); ++$i) {
             $token = $tokens[$i];
 

--- a/ContentElement/Loader/AnnotationClassLoader.php
+++ b/ContentElement/Loader/AnnotationClassLoader.php
@@ -115,7 +115,7 @@ class AnnotationClassLoader implements LoaderInterface
     {
     }
 
-    protected function addRenderDefinition(RenderDefinitionCollection $collection, ContentElement $annot, \ReflectionClass $class, \ReflectionMethod $method)
+    protected function addRenderDefinition(RenderDefinitionCollection $collection, ContentElement $annot, \ReflectionClass $class, \ReflectionMethod $method): void
     {
         $name = $annot->getName();
         if (null === $name) {

--- a/ContentElement/Loader/AnnotationClassLoader.php
+++ b/ContentElement/Loader/AnnotationClassLoader.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\ContentElement\Loader;
 

--- a/ContentElement/RenderDefinition.php
+++ b/ContentElement/RenderDefinition.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\ContentElement;
 

--- a/ContentElement/RenderDefinitionCollection.php
+++ b/ContentElement/RenderDefinitionCollection.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\ContentElement;
 

--- a/ContentElement/Renderer.php
+++ b/ContentElement/Renderer.php
@@ -25,6 +25,7 @@ use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -75,21 +76,28 @@ class Renderer
     public $cObj;
 
     /**
+     * @var ArgumentResolverInterface
+     */
+    private $argumentResolver;
+
+    /**
      * @DI\InjectParams(params={
      *      "requestStack" = @DI\Inject("request_stack"),
      *      "kernel" = @DI\Inject("http_kernel"),
      *      "routerListener" = @DI\Inject("router_listener"),
      *      "resolver" = @DI\Inject("controller_resolver"),
      *      "frontendController" = @DI\Inject("typo3.frontend_controller"),
+     *      "argumentResolver" = @DI\Inject("argument_resolver"),
      * })
      */
-    public function __construct(RequestStack $requestStack, HttpKernel $kernel, RouterListener $routerListener, ControllerResolverInterface $resolver, TypoScriptFrontendController $frontendController)
+    public function __construct(RequestStack $requestStack, HttpKernel $kernel, RouterListener $routerListener, ControllerResolverInterface $resolver, TypoScriptFrontendController $frontendController, ArgumentResolverInterface $argumentResolver)
     {
         $this->requestStack = $requestStack;
         $this->kernel = $kernel;
         $this->routerListener = $routerListener;
         $this->resolver = $resolver;
         $this->frontendController = $frontendController;
+        $this->argumentResolver = $argumentResolver;
     }
 
     /**
@@ -126,8 +134,9 @@ class Renderer
         }
 
         // controller arguments
-        $arguments = $this->resolver->getArguments($request, $controller);
+        $arguments = $this->argumentResolver->getArguments($request, $controller);
 
+        $response = null;
         try {
             // call controller
             $response = call_user_func_array($controller, $arguments);

--- a/ContentElement/Renderer.php
+++ b/ContentElement/Renderer.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\ContentElement;
 

--- a/DependencyInjection/BartacusExtension.php
+++ b/DependencyInjection/BartacusExtension.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class BartacusExtension extends Extension implements PrependExtensionInterface
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader(
             $container,
@@ -49,7 +49,7 @@ class BartacusExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('bartacus.paths.web_dir', $config['paths']['web_dir']);
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $bundles = $container->getParameter('kernel.bundles');
         if (!isset($bundles['JMSDiExtraBundle'])) {

--- a/DependencyInjection/BartacusExtension.php
+++ b/DependencyInjection/BartacusExtension.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\DependencyInjection;
 

--- a/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
+++ b/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class TypoScriptUserFuncPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('bartacus.typoscript.user_func_collector')) {
             return;

--- a/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
+++ b/DependencyInjection/Compiler/TypoScriptUserFuncPass.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\DependencyInjection\Compiler;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\DependencyInjection;
 

--- a/EventListener/ContentObjectListener.php
+++ b/EventListener/ContentObjectListener.php
@@ -51,7 +51,7 @@ class ContentObjectListener
     /**
      * @DI\Observe(KernelEvents::REQUEST, priority=8)
      */
-    public function onKernelRequest()
+    public function onKernelRequest(): void
     {
         if (!$this->frontendController->cObj instanceof ContentObjectRenderer) {
             $this->frontendController->newCObj();

--- a/EventListener/ContentObjectListener.php
+++ b/EventListener/ContentObjectListener.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\EventListener;
 

--- a/Exception/DependencyUnsatisfiedException.php
+++ b/Exception/DependencyUnsatisfiedException.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Exception;
 

--- a/Http/Factory/Typo3PsrMessageFactory.php
+++ b/Http/Factory/Typo3PsrMessageFactory.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Http\Factory;
 

--- a/Http/FrontendApplication.php
+++ b/Http/FrontendApplication.php
@@ -107,7 +107,7 @@ class FrontendApplication implements ApplicationInterface
      *
      * @param callable $execute
      */
-    public function run(callable $execute = null)
+    public function run(callable $execute = null): void
     {
         $this->bootstrap->handleRequest(ServerRequestFactory::fromGlobals());
 
@@ -133,7 +133,7 @@ class FrontendApplication implements ApplicationInterface
      * @param Request  $request
      * @param Response $response
      */
-    public static function setRequestResponseForTermination(Request $request, Response $response)
+    public static function setRequestResponseForTermination(Request $request, Response $response): void
     {
         self::$request = $request;
         self::$response = $response;

--- a/Http/FrontendApplication.php
+++ b/Http/FrontendApplication.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Http;
 

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -116,7 +116,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
      *
      * @return null|ResponseInterface
      */
-    public function handleRequest(ServerRequestInterface $request)
+    public function handleRequest(ServerRequestInterface $request): ?ResponseInterface
     {
         $response = null;
         $this->request = $request;
@@ -407,7 +407,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
      * Initializes output compression when enabled, could be split up and put into Bootstrap
      * at a later point.
      */
-    protected function initializeOutputCompression()
+    protected function initializeOutputCompression(): void
     {
         if ($GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'] && extension_loaded('zlib')) {
             if (MathUtility::canBeInterpretedAsInteger($GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'])) {
@@ -420,7 +420,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     /**
      * Timetracking started depending if a Backend User is logged in.
      */
-    protected function initializeTimeTracker()
+    protected function initializeTimeTracker(): void
     {
         $configuredCookieName = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
 
@@ -433,7 +433,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     /**
      * Creates an instance of TSFE and sets it as a global variable.
      */
-    protected function initializeController()
+    protected function initializeController(): void
     {
         $this->controller = GeneralUtility::makeInstance(
             TypoScriptFrontendController::class,
@@ -455,13 +455,9 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     }
 
     /**
-     * @param Request $request
-     *
      * @throws \Exception
-     *
-     * @return ResponseInterface
      */
-    protected function handleSymfonyRequest(Request $symfonyRequest)
+    protected function handleSymfonyRequest(Request $symfonyRequest): ?ResponseInterface
     {
         $this->timeTracker->push('Symfony request handling', '');
 

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -17,7 +17,7 @@
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Bartacus\Bundle\BartacusBundle\Http;
 
@@ -116,7 +116,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
      *
      * @return null|ResponseInterface
      */
-    public function handleRequest(ServerRequestInterface $request): ?ResponseInterface
+    public function handleRequest(ServerRequestInterface $request): ? ResponseInterface
     {
         $response = null;
         $this->request = $request;
@@ -156,6 +156,8 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
         $this->bootstrap->endOutputBufferingAndCleanPreviousOutput();
         $this->initializeOutputCompression();
 
+        $this->bootstrap->loadBaseTca();
+
         // Initializing the Frontend User
         $this->timeTracker->push('Front End user initialized', '');
         $this->controller->initFEuser();
@@ -174,10 +176,8 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
             $GLOBALS['BE_USER']->initializeAdminPanel();
             $this->bootstrap
                 ->initializeBackendRouter()
-                ->loadExtensionTables()
+                ->loadExtTables()
             ;
-        } else {
-            $this->bootstrap->loadCachedTca();
         }
 
         $httpFoundationFactory = new HttpFoundationFactory();
@@ -267,6 +267,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
             $this->controller->initializeRedirectUrlHandlers();
 
             $this->controller->handleDataSubmission();
+
             // Check for shortcut page and redirect
             $this->controller->checkPageForShortcutRedirect();
             $this->controller->checkPageForMountpointRedirect();
@@ -424,9 +425,11 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     {
         $configuredCookieName = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
 
-        /* @var TimeTracker timeTracker */
-        $this->timeTracker = GeneralUtility::makeInstance(TimeTracker::class,
-            ($this->request->getCookieParams()[$configuredCookieName] ? true : false));
+        /** @var TimeTracker timeTracker */
+        $this->timeTracker = GeneralUtility::makeInstance(
+            TimeTracker::class,
+            ($this->request->getCookieParams()[$configuredCookieName] ? true : false)
+        );
         $this->timeTracker->start();
     }
 
@@ -457,7 +460,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     /**
      * @throws \Exception
      */
-    protected function handleSymfonyRequest(Request $symfonyRequest): ?ResponseInterface
+    protected function handleSymfonyRequest(Request $symfonyRequest): ? ResponseInterface
     {
         $this->timeTracker->push('Symfony request handling', '');
 

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types = 1);
 
 namespace Bartacus\Bundle\BartacusBundle\Http;
 
@@ -425,7 +427,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
     {
         $configuredCookieName = trim($GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']) ?: 'be_typo_user';
 
-        /** @var TimeTracker timeTracker */
+        /* @var TimeTracker timeTracker */
         $this->timeTracker = GeneralUtility::makeInstance(
             TimeTracker::class,
             ($this->request->getCookieParams()[$configuredCookieName] ? true : false)

--- a/Resources/config/overrides.xml
+++ b/Resources/config/overrides.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ This file is part of the BartacusBundle.
+  ~ This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+  ~
+  ~ Copyright (c) 2016-2017 Patrik Karisch
   ~
   ~ The BartacusBundle is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/Resources/config/typo3.xml
+++ b/Resources/config/typo3.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ This file is part of the BartacusBundle.
+  ~ This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+  ~
+  ~ Copyright (c) 2016-2017 Patrik Karisch
   ~
   ~ The BartacusBundle is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/Resources/doc/copyright.rst
+++ b/Resources/doc/copyright.rst
@@ -5,7 +5,7 @@ Copyright
 
 .. |copy|   unicode:: U+000A9 .. COPYRIGHT SIGN
 
-Copyright |copy| 2016, Patrik Karisch
+Copyright |copy| 2016-2017, Patrik Karisch
 
 All rights reserved.  This material may be copied or distributed only
 subject to the terms and conditions set forth in the `Creative Commons

--- a/Resources/scripts/Install.php
+++ b/Resources/scripts/Install.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use TYPO3\CMS\Install\Http\Application;
 

--- a/Resources/scripts/backend.php
+++ b/Resources/scripts/backend.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use TYPO3\CMS\Backend\Http\Application;
 

--- a/Resources/scripts/cli.php
+++ b/Resources/scripts/cli.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use TYPO3\CMS\Backend\Console\Application;
 

--- a/Resources/scripts/index.php
+++ b/Resources/scripts/index.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use Bartacus\Bundle\BartacusBundle\Http\FrontendApplication;
 

--- a/Resources/scripts/kernel.php
+++ b/Resources/scripts/kernel.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use Symfony\Component\Debug\Debug;
 

--- a/Resources/scripts/package.php
+++ b/Resources/scripts/package.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 use TYPO3\CMS\Core\Compatibility\LoadedExtensionArrayElement;
 use TYPO3\CMS\Core\Core\Bootstrap;

--- a/Session/Storage/PhpBridgeSessionStorage.php
+++ b/Session/Storage/PhpBridgeSessionStorage.php
@@ -31,7 +31,7 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
     /**
      * {@inheritdoc}
      */
-    public function start()
+    public function start(): bool
     {
         if ($this->started) {
             return true;
@@ -59,7 +59,7 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): void
     {
         // clear out the bags and nothing else that may be set
         // since the purpose of this driver is to share a handler

--- a/Session/Storage/PhpBridgeSessionStorage.php
+++ b/Session/Storage/PhpBridgeSessionStorage.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Session\Storage;
 

--- a/Typo3/ServiceBridge.php
+++ b/Typo3/ServiceBridge.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Typo3;
 

--- a/TypoScript/UserFuncCollector.php
+++ b/TypoScript/UserFuncCollector.php
@@ -44,7 +44,7 @@ class UserFuncCollector
      * @param string $className
      * @param object $instance
      */
-    public function addUserFunc(string $className, $instance)
+    public function addUserFunc(string $className, $instance): void
     {
         $this->userFuncs[$className] = $instance;
     }
@@ -52,7 +52,7 @@ class UserFuncCollector
     /**
      * Loads all registered instances into the {@see GeneralUtility::makeInstance()} singleton cache.
      */
-    public function loadUserFuncs()
+    public function loadUserFuncs(): void
     {
         $refl = new \ReflectionClass(GeneralUtility::class);
         $reflProp = $refl->getProperty('singletonInstances');

--- a/TypoScript/UserFuncCollector.php
+++ b/TypoScript/UserFuncCollector.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
- * This file is part of the BartacusBundle.
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
  *
  * The BartacusBundle is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
-
-declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\TypoScript;
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.1",
         "typo3/cms": "8.4.*",
-        "symfony/symfony": "^3.0",
+        "symfony/symfony": "^3.2",
         "symfony/psr-http-message-bridge": "^1.0",
         "jms/di-extra-bundle": "^1.8",
         "ocramius/proxy-manager": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "typo3/cms": "8.4.*",
+        "typo3/cms": "^8.6",
         "symfony/symfony": "^3.2",
         "symfony/psr-http-message-bridge": "^1.0",
         "jms/di-extra-bundle": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "7.0.*",
+        "php": "^7.1",
         "typo3/cms": "8.4.*",
         "symfony/symfony": "^3.0",
         "symfony/psr-http-message-bridge": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ocramius/proxy-manager": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1.12"
+        "friendsofphp/php-cs-fixer": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #50 
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Updates the bundle to TYPO3 8.6 and raises requirements to PHP 7.1 and Symfony 3.2. Also the code style is updated and copyright fixed.