### PR TITLE
Set temp path for http foundation factory within PATH_site

### DIFF
--- a/Http/Factory/Typo3HttpFoundationFactory.php
+++ b/Http/Factory/Typo3HttpFoundationFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) 2016-2017 Patrik Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Http\Factory;
+
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\Filesystem\Filesystem;
+
+class Typo3HttpFoundationFactory extends HttpFoundationFactory
+{
+    /**
+     * Gets a temporary file path within TYPO3, because they
+     * enforce uploaded files to be moved within path_SITE,
+     * breaking the interface.
+     */
+    protected function getTemporaryPath(): string
+    {
+        $path = \PATH_site.'typo3temp/var/uploads';
+
+        $fs = new Filesystem();
+        $fs->mkdir($path, 0770);
+
+        return \tempnam($path, \uniqid('symfony', true));
+    }
+}

--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\Http;
 
+use Bartacus\Bundle\BartacusBundle\Http\Factory\Typo3HttpFoundationFactory;
 use Bartacus\Bundle\BartacusBundle\Http\Factory\Typo3PsrMessageFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -181,7 +181,7 @@ class SymfonyFrontendRequestHandler implements RequestHandlerInterface
             ;
         }
 
-        $httpFoundationFactory = new HttpFoundationFactory();
+        $httpFoundationFactory = new Typo3HttpFoundationFactory();
         $symfonyRequest = $httpFoundationFactory->createRequest($request);
 
         try {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #69 
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Sets the temporary path for the uploaded file in the http foundation factory to be within PATH_site :sob: 