### PR TITLE
Work with the TYPO3 console

### DIFF
--- a/Bootstrap/SymfonyBootstrap.php
+++ b/Bootstrap/SymfonyBootstrap.php
@@ -43,7 +43,7 @@ final class SymfonyBootstrap
     {
         /** @var PackageManager $packageManager */
         $packageManager = Bootstrap::getInstance()->getEarlyInstance(PackageManager::class);
-        $package = new Package($packageManager, 'app', \realpath(self::$kernel->getProjectDir().'/app/'));
+        $package = new Package($packageManager, 'app', \rtrim(\realpath(self::$kernel->getProjectDir().'/app/'), '\\/').'/');
         $packageManager->registerPackage($package);
 
         \Closure::bind(function (PackageManager $instance) use ($package) {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "friendsofphp/php-cs-fixer": "^2.2"
     },
     "conflict": {
+        "helhum/typo3-console": "<4.7.0 >4.7.0",
         "jms/di-extra-bundle": "*"
     },
     "autoload": {
@@ -45,6 +46,9 @@
         "patches": {
             "typo3/cms": {
                 "Patch all TYPO3 entry points for proper Symfony kernel bootstrap": "https://github.com/Bartacus/TYPO3.CMS/compare/8.7.4...patch/8.7.4/bartacus-entry-scripts.patch"
+            },
+            "helhum/typo3-console": {
+                "Patch console entry script for proper Symfony kernel bootstrap": "https://github.com/Bartacus/TYPO3-Console/compare/4.7.0...patch/4.7.0/bartacus-entry-script.patch"
             }
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #57
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

This adds a patch to the TYPO3 console if installed, so the symfony kernel is bootstrapped to, if the console is used. This adds strict version requirement to the console, but it doesn't automatically install it (thanks to the conflicts section)