### PR TITLE
Add ConnectionPool to typo3 services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Register TYPO3 ConnectionPool as Symfony service
+
 ## [1.0.1] - 2017-09-08
 ### Fixed
 - Compatibility with TYPO3 8.7.6

--- a/Resources/config/typo3.xml
+++ b/Resources/config/typo3.xml
@@ -102,5 +102,10 @@
             <factory service="Bartacus\Bundle\BartacusBundle\Typo3\ServiceBridge" method="makeInstance"/>
             <argument>TYPO3\CMS\Core\Registry</argument>
         </service>
+
+        <service id="TYPO3\CMS\Core\Database\ConnectionPool" shared="false">
+            <factory service="Bartacus\Bundle\BartacusBundle\Typo3\ServiceBridge" method="makeInstance" />
+            <argument>TYPO3\CMS\Core\Database\ConnectionPool</argument>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | none
| Related issues/PRs | none
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

Add Connection Pool to services because DatabaseConnection is deprecated
