### PR TITLE
Provide local patches instead of relying on GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Provide local patches instead of relying on GitHub
 
 ## [1.1.9] - 2018-08-06
 ### Fixed

--- a/Resources/patches/helhum/typo3-console/bartacus-entry-script.patch
+++ b/Resources/patches/helhum/typo3-console/bartacus-entry-script.patch
@@ -1,0 +1,28 @@
+From 4a2fe5b7e57234a6e86f680e2110fb6f3b19391b Mon Sep 17 00:00:00 2001
+From: Patrik Karisch <patrik@karisch.guru>
+Date: Thu, 31 Aug 2017 11:35:30 +0200
+Subject: [PATCH] Patch console entry script for proper Symfony kernel
+ bootstrap
+
+---
+ Scripts/typo3cms.php | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/Scripts/typo3cms.php b/Scripts/typo3cms.php
+index b9001f1e..b3f4bab8 100644
+--- a/Scripts/typo3cms.php
++++ b/Scripts/typo3cms.php
+@@ -61,6 +61,12 @@
+         // where requiring the main autoload.php is not enough to load extension classes
+         require __DIR__ . '/../Classes/Core/ConsoleBootstrap.php';
+     }
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
+     $bootstrap = \Helhum\Typo3Console\Core\ConsoleBootstrap::create(getenv('TYPO3_CONTEXT') ?: 'Production');
+-    $bootstrap->run($classLoader);
++    $bootstrap->initialize($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $bootstrap->registerRequestHandler(new \Helhum\Typo3Console\Mvc\Cli\RequestHandler($bootstrap));
++    $bootstrap->resolveCliRequestHandler()->handleRequest();
+ });

--- a/Resources/patches/typo3/cms-cli/bartacus-entry-scripts.patch
+++ b/Resources/patches/typo3/cms-cli/bartacus-entry-scripts.patch
@@ -1,0 +1,25 @@
+From 74118ac37058e2af2467649ee2b186cef67697fc Mon Sep 17 00:00:00 2001
+From: Patrik Karisch <p.karisch@pixelart.at>
+Date: Fri, 8 Sep 2017 09:33:18 +0200
+Subject: [PATCH] Patch entry point for proper Symfony kernel bootstrap
+
+---
+ typo3 | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/typo3 b/typo3
+index 25506c2..0fe43f8 100755
+--- a/typo3
++++ b/typo3
+@@ -19,5 +19,10 @@
+  */
+ call_user_func(function() {
+     $classLoader = require __DIR__ . '/../../autoload.php';
+-    (new \TYPO3\CMS\Cli\CommandApplication($classLoader))->run();
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \TYPO3\CMS\Cli\CommandApplication($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });

--- a/Resources/patches/typo3/cms/bartacus-entry-scripts.patch
+++ b/Resources/patches/typo3/cms/bartacus-entry-scripts.patch
@@ -1,0 +1,95 @@
+From 8722e8882d8598330a97ca82f2c207f1ede188f2 Mon Sep 17 00:00:00 2001
+From: Patrik Karisch <patrik@karisch.guru>
+Date: Thu, 31 Aug 2017 09:15:12 +0200
+Subject: [PATCH] Patch all TYPO3 entry points for proper Symfony kernel
+ bootstrap
+
+---
+ typo3/sysext/backend/Resources/Private/Php/backend.php |  6 +++++-
+ typo3/sysext/backend/Resources/Private/Php/cli.php     |  6 +++++-
+ typo3/sysext/core/bin/typo3                            |  7 ++++++-
+ .../sysext/frontend/Resources/Private/Php/frontend.php | 10 +++++++++-
+ typo3/sysext/install/Resources/Private/Php/install.php |  7 ++++++-
+ 5 files changed, 31 insertions(+), 5 deletions(-)
+
+diff --git a/typo3/sysext/backend/Resources/Private/Php/backend.php b/typo3/sysext/backend/Resources/Private/Php/backend.php
+index ca1dee27e2..33eb88127a 100644
+--- a/typo3/sysext/backend/Resources/Private/Php/backend.php
++++ b/typo3/sysext/backend/Resources/Private/Php/backend.php
+@@ -21,5 +21,9 @@
+ call_user_func(function () {
+     $classLoader = require __DIR__ . '/../../../../../../vendor/autoload.php';
+ 
+-    (new \TYPO3\CMS\Backend\Http\Application($classLoader))->run();
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \TYPO3\CMS\Backend\Http\Application($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });
+diff --git a/typo3/sysext/backend/Resources/Private/Php/cli.php b/typo3/sysext/backend/Resources/Private/Php/cli.php
+index 925c6c6645..a3f7d7bceb 100644
+--- a/typo3/sysext/backend/Resources/Private/Php/cli.php
++++ b/typo3/sysext/backend/Resources/Private/Php/cli.php
+@@ -32,5 +32,9 @@
+ call_user_func(function () {
+     $classLoader = require __DIR__ . '/../../../../../../vendor/autoload.php';
+ 
+-    (new \TYPO3\CMS\Backend\Console\Application($classLoader))->run();
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \TYPO3\CMS\Backend\Console\Application($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });
+diff --git a/typo3/sysext/core/bin/typo3 b/typo3/sysext/core/bin/typo3
+index 9b32140269..aba1fa2b81 100755
+--- a/typo3/sysext/core/bin/typo3
++++ b/typo3/sysext/core/bin/typo3
+@@ -19,5 +19,10 @@
+  */
+ call_user_func(function() {
+     $classLoader = require __DIR__ . '/../../../../vendor/autoload.php';
+-    (new \TYPO3\CMS\Core\Console\CommandApplication($classLoader))->run();
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \TYPO3\CMS\Core\Console\CommandApplication($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });
+diff --git a/typo3/sysext/frontend/Resources/Private/Php/frontend.php b/typo3/sysext/frontend/Resources/Private/Php/frontend.php
+index 00b9bcf60d..02ee874412 100644
+--- a/typo3/sysext/frontend/Resources/Private/Php/frontend.php
++++ b/typo3/sysext/frontend/Resources/Private/Php/frontend.php
+@@ -20,5 +20,13 @@
+ // Set up the application for the Frontend
+ call_user_func(function () {
+     $classLoader = require __DIR__ . '/../../../../../../vendor/autoload.php';
+-    (new \TYPO3\CMS\Frontend\Http\Application($classLoader))->run();
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \Bartacus\Bundle\BartacusBundle\Http\FrontendApplication(
++        $classLoader,
++        \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::getKernel()
++    );
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });
+diff --git a/typo3/sysext/install/Resources/Private/Php/install.php b/typo3/sysext/install/Resources/Private/Php/install.php
+index e175d1b2b2..b26f33b995 100644
+--- a/typo3/sysext/install/Resources/Private/Php/install.php
++++ b/typo3/sysext/install/Resources/Private/Php/install.php
+@@ -100,5 +100,10 @@
+ 
+ call_user_func(function () {
+     $classLoader = require __DIR__ . '/../../../../../../vendor/autoload.php';
+-    (new \TYPO3\CMS\Install\Http\Application($classLoader))->run();
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initKernel();
++    $application = new \TYPO3\CMS\Install\Http\Application($classLoader);
++
++    \Bartacus\Bundle\BartacusBundle\Bootstrap\SymfonyBootstrap::initAppPackage();
++    $application->run();
+ });

--- a/bin/fetch-patch-files.sh
+++ b/bin/fetch-patch-files.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+
+# typo3/cms
+mkdir -p Resources/patches/typo3/cms
+typo3_version="$(composer show typo3/cms | grep versions | awk '{print $4}' | sed s/v//)"
+
+wget -O Resources/patches/typo3/cms/bartacus-entry-scripts.patch https://github.com/Bartacus/TYPO3.CMS/compare/${typo3_version}...patch/${typo3_version}/bartacus-entry-scripts.patch
+
+
+# typo3/cms-cli
+mkdir -p Resources/patches/typo3/cms-cli
+typo3_cli_version="$(composer show typo3/cms-cli | grep versions | awk '{print $4}' | awk -F"." '{print $1"."$2}')"
+
+wget -O Resources/patches/typo3/cms-cli/bartacus-entry-scripts.patch https://github.com/Bartacus/cms-cli/compare/master...patch/${typo3_cli_version}/bartacus-entry-script.patch
+
+
+# helhum/typo3-console
+mkdir -p Resources/patches/helhum/typo3-console
+typo3_console_version="$(grep helhum/typo3-console composer.json | head -n1 | awk '{ print $2}' | sed s/\"\<//)"
+
+wget -O Resources/patches/helhum/typo3-console/bartacus-entry-script.patch https://github.com/Bartacus/TYPO3-Console/compare/${typo3_console_version}...patch/${typo3_console_version}/bartacus-entry-script.patch

--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,13 @@
         },
         "patches": {
             "typo3/cms": {
-                "Patch all TYPO3 entry points for proper Symfony kernel bootstrap": "https://github.com/Bartacus/TYPO3.CMS/compare/8.7.17...patch/8.7.17/bartacus-entry-scripts.patch"
+                "Patch all TYPO3 entry points for proper Symfony kernel bootstrap": "Resources/patches/typo3/cms/bartacus-entry-scripts.patch"
             },
             "typo3/cms-cli": {
-                "Patch entry point for proper Symfony kernel bootstrap": "https://github.com/Bartacus/cms-cli/compare/master...patch/1.0/bartacus-entry-script.patch"
+                "Patch entry point for proper Symfony kernel bootstrap": "Resources/patches/typo3/cms-cli/bartacus-entry-scripts.patch"
             },
             "helhum/typo3-console": {
-                "Patch console entry script for proper Symfony kernel bootstrap": "https://github.com/Bartacus/TYPO3-Console/compare/4.7.0...patch/4.7.0/bartacus-entry-script.patch"
+                "Patch console entry script for proper Symfony kernel bootstrap": "Resources/patches/helhum/typo3-console/bartacus-entry-script.patch"
             }
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Fetches the given patches still from the GitHub patch endpoint, but commits them to the repository. This makes the patching independent from the availability of GitHub on the patch URLs and it can be installed only from composer cache.
