### PR TITLE
Force parsing the TemplateService configuration for Symfony routes

### DIFF
--- a/Http/SymfonyFrontendRequestHandler.php
+++ b/Http/SymfonyFrontendRequestHandler.php
@@ -199,6 +199,12 @@ class SymfonyFrontendRequestHandler extends RequestHandler
         $this->timeTracker->push('Get Page from cache', '');
         $this->controller->getFromCache();
         $this->timeTracker->pull();
+
+        if (!$handleWithRealUrl) {
+            // force parsing the TemplateService model if dealing with Symfony routes
+            // otherwise the TemplateService configuration would be empty
+            $this->controller->forceTemplateParsing = true;
+        }
         // Get config if not already gotten
         // After this, we should have a valid config-array ready
         $this->controller->getConfigArray();


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #85 
| Related issues/PRs | connects to #
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?
When dealing with Symfony routes the TYPO3 FrontendController is loaded from cache and therefore the TemplateService property isn't initialized correctly. This results in an empty TemplateService configuration which may be required by a service (e.g. reading Solr TypoScript configuration).
