### PR TITLE
Add PageArguments (with page id) to the request

### DIFF
--- a/Middleware/SymfonyRouteResolver.php
+++ b/Middleware/SymfonyRouteResolver.php
@@ -151,14 +151,11 @@ class SymfonyRouteResolver implements MiddlewareInterface
         $site = $request->getAttribute('site', null);
 
         if ($requestId || !($site instanceof  SiteInterface)) {
-
             return $request;
         }
 
-
         $routeResult = $request->getAttribute('routing', null);
         if (!($routeResult->getLanguage() instanceof SiteLanguage)) {
-
             return $request;
         }
 
@@ -166,7 +163,6 @@ class SymfonyRouteResolver implements MiddlewareInterface
             /** @var PageArguments $pageArguments */
             $pageArguments = $site->getRouter()->matchRequest($request, $routeResult);
         } catch (RouteNotFoundException $e) {
-
             return $request;
         }
 

--- a/Middleware/SymfonyRouteResolver.php
+++ b/Middleware/SymfonyRouteResolver.php
@@ -157,7 +157,7 @@ class SymfonyRouteResolver implements MiddlewareInterface
 
 
         $routeResult = $request->getAttribute('routing', null);
-        if (!($routeResult->getLanguage() instanceof SiteLanguage)){
+        if (!($routeResult->getLanguage() instanceof SiteLanguage)) {
 
             return $request;
         }
@@ -172,7 +172,7 @@ class SymfonyRouteResolver implements MiddlewareInterface
 
         $preparedRequest = $request->withAttribute('routing', $pageArguments);
         // merge the PageArguments with the request query parameters
-        $queryParams = array_replace_recursive(
+        $queryParams = \array_replace_recursive(
             $preparedRequest->getQueryParams(),
             $pageArguments->getArguments()
         );

--- a/Typo3/ServiceBridge.php
+++ b/Typo3/ServiceBridge.php
@@ -39,7 +39,7 @@ class ServiceBridge
      * @var ObjectManagerInterface
      */
     private $extbaseObjectManager;
-    
+
     /**
      * Wrapper around {@see GeneralUtility::makeInstance()}.
      *


### PR DESCRIPTION
| Q | A
| --- | ---
| License | GPL-3.0+

#### What's in this PR?
Makes requested page id available in symfony request (for valid typo3 routes).

Example: 
```
/** @var \TYPO3\CMS\Core\Routing\PageArguments $routing */
$routing = $this->request->get('page');
$id = ($routing instanceof PageArguments) ? $routing->getPageId() : 1
```
Reworked the way the locale is set, so the site config is used instead of the TSFE configuration.