### PR TITLE
Set locale from correct site language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Support for TYPO3 9.5
 - Minimal required Symfony version is 4.2
+- Symfony translator locale is now retrieved from site settings instead of TypoScript config
 
 ### Removed
 - The `$GLOBALS['kernel']` variable is removed, use `SymfonyBootstrap::getKernel()` instead


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | replaces #90 partly
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Sets the correct symfony translator locale from new site settings