### PR TITLE
Fetch setup for site root if not present (for symfony routes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fetch TypoScript setup for site root on Symfony routes 
 
 ## [2.0.2] - 2019-04-18
 ### Changed

--- a/EventSubscriber/FrontendControllerSubscriber.php
+++ b/EventSubscriber/FrontendControllerSubscriber.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelEvents;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -71,6 +72,13 @@ class FrontendControllerSubscriber implements EventSubscriberInterface
                     TemplateService::class,
                     GeneralUtility::makeInstance(Context::class)
                 );
+            }
+
+            $site = $event->getRequest()->attributes->get('site');
+            if (empty($frontendController->tmpl->setup) && $site instanceof SiteInterface) {
+                $frontendController->id = $site->getRootPageId();
+                $frontendController->determineId();
+                $frontendController->getConfigArray();
             }
 
             if (!$frontendController->sys_page instanceof PageRepository) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #85
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?
Get the setup of the site root by default
