### PR TITLE
Fix symfony route resolver order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Fetch TypoScript setup for site root on Symfony routes 
+- Fetch TypoScript setup for site root on Symfony routes
+- Change order of `base-redirect-resolver` and `static-route-resolver` from TYPO3
+- The Symfony route resolver is placed before the `base-redirect-resolver`, but after all other redirects
 
 ## [2.0.2] - 2019-04-18
 ### Changed

--- a/Config/ConfigLoader.php
+++ b/Config/ConfigLoader.php
@@ -50,8 +50,26 @@ class ConfigLoader
 
     public function loadFromRequestMiddlewares(): array
     {
+        $frontendMiddlewares = require \dirname(__DIR__, 4).'/public/typo3/sysext/frontend/Configuration/RequestMiddlewares.php';
+
         return [
             'frontend' => [
+                'typo3/cms-frontend/static-route-resolver' => \array_merge($frontendMiddlewares['frontend']['typo3/cms-frontend/static-route-resolver'], [
+                    'after' => [
+                        'typo3/cms-frontend/site-resolver',
+                    ],
+                    'before' => [
+                        'typo3/cms-frontend/base-redirect-resolver',
+                    ],
+                ]),
+                'typo3/cms-frontend/base-redirect-resolver' => \array_merge($frontendMiddlewares['frontend']['typo3/cms-frontend/base-redirect-resolver'], [
+                    'after' => [
+                        'typo3/cms-frontend/static-route-resolver',
+                    ],
+                    'before' => [
+                        'typo3/cms-frontend/page-resolver',
+                    ],
+                ]),
                 'bartacus/symfony-route-resolver' => [
                     'target' => SymfonyRouteResolver::class,
                     'after' => [

--- a/Config/ConfigLoader.php
+++ b/Config/ConfigLoader.php
@@ -59,11 +59,11 @@ class ConfigLoader
                         'typo3/cms-frontend/backend-user-authentication',
                         'typo3/cms-frontend/tsfe',
                         'typo3/cms-frontend/site',
-                        'typo3/cms-frontend/base-redirect-resolver',
                         'typo3/cms-frontend/static-route-resolver',
                         'typo3/cms-redirects/redirecthandler',
                     ],
                     'before' => [
+                        'typo3/cms-frontend/base-redirect-resolver',
                         'typo3/cms-frontend/page-resolver',
                     ],
                 ],

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.5",
         "symfony/debug": "^4.2",
-        "symfony/twig-bundle": "^4.2"
+        "symfony/twig-bundle": "^4.2",
+        "typo3/cms-redirects": "^9.5"
     },
     "conflict": {
         "jms/di-extra-bundle": "*"


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-3.0+

#### What's in this PR?

Fixes the symfony route resolver order to be executed before the base route resolver and after all other redirects.

This required to fix the redirect resolvers order of TYPO3 in generel.


Test in your project with the following in your `composer.json`

```
"bartacus/bartacus-bundle": "dev-fix/symfony-resolver-order as 2.0.3"
```