### PR TITLE
Extract all config loading into events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added `bartacus.config.additional_configuration` event when the `AdditionalConfiguration.php` is loaded
+- Added `bartacus.config.request_middlewares` event when the request middlewares of the app are loaded
+
+### Changed
+- [internal] Moved code from config loader into the appropriate event subscribers
 
 ## [2.0.3] - 2019-05-23
 ### Fixed

--- a/ConfigEvents.php
+++ b/ConfigEvents.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle;
+
+/**
+ * Contains all events thrown in the config loader.
+ */
+final class ConfigEvents
+{
+    /**
+     * The ADDITIONAL_CONFIGURATION event occurs at the very beginning
+     * when the AdditionalConfiguration.php is parsed.
+     *
+     * Useful to modify the $GLOBALS['TYPO3_CONF_VARS'] or load TypoScript.
+     *
+     * @Event("Symfony\Component\EventDispatcher\Event")
+     */
+    public const ADDITIONAL_CONFIGURATION = 'bartacus.config.additional_configuration';
+
+    /**
+     * The REQUEST_MIDDLEWARES event occurs at when the request middlewares
+     * of the app extension are loaded.
+     *
+     * @Event("Bartacus\Bundle\BartacusBundle\Event\RequestMiddlewaresEvent")
+     */
+    public const REQUEST_MIDDLEWARES = 'bartacus.config.request_middlewares';
+}

--- a/Event/RequestMiddlewaresEvent.php
+++ b/Event/RequestMiddlewaresEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+final class RequestMiddlewaresEvent extends Event
+{
+    /**
+     * @var array
+     */
+    private $requestMiddlewares = [[]];
+
+    public function getRequestMiddlewares(): array
+    {
+        return \array_replace_recursive(...$this->requestMiddlewares);
+    }
+
+    public function addRequestMiddlewares(array $requestMiddlewares): void
+    {
+        $this->requestMiddlewares[] = $requestMiddlewares;
+    }
+}

--- a/EventSubscriber/BartacusRequestMiddlewaresSubscriber.php
+++ b/EventSubscriber/BartacusRequestMiddlewaresSubscriber.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\EventSubscriber;
+
+use Bartacus\Bundle\BartacusBundle\ConfigEvents;
+use Bartacus\Bundle\BartacusBundle\Event\RequestMiddlewaresEvent;
+use Bartacus\Bundle\BartacusBundle\Middleware\PrepareContentElementRenderer;
+use Bartacus\Bundle\BartacusBundle\Middleware\SymfonyRouteResolver;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class BartacusRequestMiddlewaresSubscriber implements EventSubscriberInterface
+{
+    public function loadMiddlewares(RequestMiddlewaresEvent $event): void
+    {
+        $middlewares = [
+            'frontend' => [
+                'bartacus/symfony-route-resolver' => [
+                    'target' => SymfonyRouteResolver::class,
+                    'after' => [
+                        'typo3/cms-frontend/authentication',
+                        'typo3/cms-frontend/backend-user-authentication',
+                        'typo3/cms-frontend/tsfe',
+                        'typo3/cms-frontend/site',
+                        'typo3/cms-frontend/base-redirect-resolver',
+                        'typo3/cms-frontend/static-route-resolver',
+                        'typo3/cms-redirects/redirecthandler',
+                    ],
+                    'before' => [
+                        'typo3/cms-frontend/page-resolver',
+                    ],
+                ],
+                'bartacus/prepare-content-element-renderer' => [
+                    'target' => PrepareContentElementRenderer::class,
+                    'after' => [
+                        'typo3/cms-frontend/tsfe',
+                        'typo3/cms-frontend/site',
+                        'typo3/cms-frontend/page-resolver',
+                        'typo3/cms-frontend/page-argument-validator',
+                        'typo3/cms-frontend/prepare-tsfe-rendering',
+                    ],
+                ],
+            ],
+        ];
+
+        $event->addRequestMiddlewares($middlewares);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConfigEvents::REQUEST_MIDDLEWARES => [['loadMiddlewares', 8]],
+        ];
+    }
+}

--- a/EventSubscriber/ContentElementConfigLoaderSubscriber.php
+++ b/EventSubscriber/ContentElementConfigLoaderSubscriber.php
@@ -21,38 +21,34 @@ declare(strict_types=1);
  * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace Bartacus\Bundle\BartacusBundle\Config;
+namespace Bartacus\Bundle\BartacusBundle\EventSubscriber;
 
 use Bartacus\Bundle\BartacusBundle\ConfigEvents;
-use Bartacus\Bundle\BartacusBundle\Event\RequestMiddlewaresEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Bartacus\Bundle\BartacusBundle\ContentElement\Loader\ContentElementConfigLoader;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-/**
- * Delegating central config loader called on various places within TYPO3
- * to load and configure specific parts of the system.
- */
-class ConfigLoader
+final class ContentElementConfigLoaderSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var EventDispatcherInterface
+     * @var ContentElementConfigLoader
      */
-    private $eventDispatcher;
+    private $contentElement;
 
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(ContentElementConfigLoader $contentElement)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->contentElement = $contentElement;
     }
 
-    public function loadFromAdditionalConfiguration(): void
+    public function loadContentElements(Event $event): void
     {
-        $this->eventDispatcher->dispatch(ConfigEvents::ADDITIONAL_CONFIGURATION);
+        $this->contentElement->load();
     }
 
-    public function loadFromRequestMiddlewares(): array
+    public static function getSubscribedEvents(): array
     {
-        $event = new RequestMiddlewaresEvent();
-        $this->eventDispatcher->dispatch(ConfigEvents::REQUEST_MIDDLEWARES, $event);
-
-        return $event->getRequestMiddlewares();
+        return [
+            ConfigEvents::ADDITIONAL_CONFIGURATION => [['loadContentElements', 8]],
+        ];
     }
 }

--- a/EventSubscriber/Typo3RedirectRequestMiddlewaresSubscriber.php
+++ b/EventSubscriber/Typo3RedirectRequestMiddlewaresSubscriber.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\EventSubscriber;
+
+use Bartacus\Bundle\BartacusBundle\ConfigEvents;
+use Bartacus\Bundle\BartacusBundle\Event\RequestMiddlewaresEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class Typo3RedirectRequestMiddlewaresSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    public function __construct(string $projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    public function loadMiddlewares(RequestMiddlewaresEvent $event): void
+    {
+        $frontendMiddlewares = require $this->projectDir.'/public/typo3/sysext/frontend/Configuration/RequestMiddlewares.php';
+
+        $middlewares = [
+            'frontend' => [
+                'typo3/cms-frontend/static-route-resolver' => \array_merge($frontendMiddlewares['frontend']['typo3/cms-frontend/static-route-resolver'], [
+                    'after' => [
+                        'typo3/cms-frontend/site-resolver',
+                    ],
+                    'before' => [
+                        'typo3/cms-frontend/base-redirect-resolver',
+                    ],
+                ]),
+                'typo3/cms-frontend/base-redirect-resolver' => \array_merge($frontendMiddlewares['frontend']['typo3/cms-frontend/base-redirect-resolver'], [
+                    'after' => [
+                        'typo3/cms-frontend/static-route-resolver',
+                    ],
+                    'before' => [
+                        'typo3/cms-frontend/page-resolver',
+                    ],
+                ]),
+            ],
+        ];
+
+        $event->addRequestMiddlewares($middlewares);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConfigEvents::REQUEST_MIDDLEWARES => [['loadMiddlewares', 16]],
+        ];
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,7 +45,21 @@
         </service>
 
         <service id="Bartacus\Bundle\BartacusBundle\Config\ConfigLoader" public="true">
+            <argument type="service" id="event_dispatcher" />
+        </service>
+
+        <service id="Bartacus\Bundle\BartacusBundle\EventSubscriber\ContentElementConfigLoaderSubscriber">
             <argument type="service" id="Bartacus\Bundle\BartacusBundle\ContentElement\Loader\ContentElementConfigLoader" />
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="Bartacus\Bundle\BartacusBundle\EventSubscriber\BartacusRequestMiddlewaresSubscriber">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="Bartacus\Bundle\BartacusBundle\EventSubscriber\Typo3RedirectRequestMiddlewaresSubscriber">
+            <argument>%kernel.project_dir%</argument>
+            <tag name="kernel.event_subscriber" />
         </service>
 
         <service id="Bartacus\Bundle\BartacusBundle\ContentElement\Renderer">

--- a/Resources/doc/config_loader.rst
+++ b/Resources/doc/config_loader.rst
@@ -1,0 +1,58 @@
+=============
+Config Loader
+=============
+
+The config loader component is intended for TYPO3 bundle authors. As a project developer you should use the normal extension points to define your configurations.
+
+With the config loader you can extend TYPO3 configuration and so on which is needed by your extension as a requirement.
+
+Usage
+=====
+
+The config loader dispatches several events, where you can subscribe to.
+
+The ``bartacus.config.additional_configuration`` event
+------------------------------------------------------
+
+The ``bartacus.config.additional_configuration`` event occurs at the very beginning when the ``AdditionalConfiguration.php`` is parsed.
+
+Useful to modify the ``$GLOBALS['TYPO3_CONF_VARS']`` or load TypoScript.
+
+The ``bartacus.config.request_middlewares`` event
+-------------------------------------------------
+
+The ``bartacus.config.request_middlewares`` event occurs at when the request middlewares of the app extension are loaded.
+
+Useful to register necessary middlewares on your own, without declaring the bundle as TYPO3 extension too.
+
+.. code-block:: php
+
+    <?php
+
+    namespace Acme\Bundle\AcmeBundle\EventSubscriber;
+
+    use Bartacus\Bundle\BartacusBundle\ConfigEvents;
+    use Bartacus\Bundle\BartacusBundle\Event\RequestMiddlewaresEvent;
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class RequestMiddlewaresSubscriber implements EventSubscriberInterface
+    {
+        public function loadMiddlewares(RequestMiddlewaresEvent $event): void
+        {
+            $middlewares = [
+                'frontend' => [
+                    // some middleware definitions
+                ],
+            ];
+
+            $event->addRequestMiddlewares($middlewares);
+        }
+
+        public static function getSubscribedEvents(): array
+        {
+            return [
+                ConfigEvents::REQUEST_MIDDLEWARES => 'loadMiddlewares',
+            ];
+        }
+    }
+

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -20,3 +20,4 @@ Contents
     content_elements
     service_bridge
     translations
+    config_loader


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Extracts the code from the config loader into event subscribers and dispatch new config events for it.