### PR TITLE
#98 - Terminate only if request and response are set

### DIFF
--- a/Bootstrap/SymfonyBootstrap.php
+++ b/Bootstrap/SymfonyBootstrap.php
@@ -98,7 +98,7 @@ final class SymfonyBootstrap
         // (may occur for TYPO3 StaticRoutes and PageNotFoundHandler)
         if (!self::$request instanceof Request) {
             /** @var ServerRequest $serverRequest */
-            $serverRequest = \array_key_exists('TYPO3_REQUEST', $GLOBALS) ? $GLOBALS['TYPO3_REQUEST'] : null;
+            $serverRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
 
             // try to create Symfony request based on the TYPO3 server request
             if ($serverRequest instanceof ServerRequest) {
@@ -117,9 +117,33 @@ final class SymfonyBootstrap
         self::$kernel->terminate(self::$request, self::$response);
     }
 
+    /**
+     * @internal
+     *
+     * @deprecated since 2.3.1, will be removed in 3.0, use {@see setRequestForTermination} and
+     *             {@see setResponseForTermination} instead
+     */
     public static function setRequestResponseForTermination(Request $request, Response $response): void
     {
+        @\trigger_error(\sprintf('%s since 2.3.1, will be removed in 3.0, use setRequestForTermination and setResponseForTermination instead', __METHOD__));
+
+        self::setRequestForTermination($request);
+        self::setResponseForTermination($response);
+    }
+
+    /**
+     * @internal
+     */
+    public static function setRequestForTermination(Request $request): void
+    {
         self::$request = $request;
+    }
+
+    /**
+     * @internal
+     */
+    public static function setResponseForTermination(Response $response): void
+    {
         self::$response = $response;
     }
 }

--- a/Bootstrap/SymfonyBootstrap.php
+++ b/Bootstrap/SymfonyBootstrap.php
@@ -92,7 +92,9 @@ final class SymfonyBootstrap
             Response::closeOutputBuffers(0, true);
         }
 
-        self::$kernel->terminate(self::$request, self::$response);
+        if (self::$request instanceof Request && self::$response instanceof Response) {
+            self::$kernel->terminate(self::$request, self::$response);
+        }
     }
 
     public static function setRequestResponseForTermination(Request $request, Response $response): void

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix kernel termination errors on missing request/response objects
 
 ## [2.3.0] - 2019-08-05
 ### Added

--- a/Middleware/PrepareContentElementRenderer.php
+++ b/Middleware/PrepareContentElementRenderer.php
@@ -92,13 +92,15 @@ class PrepareContentElementRenderer implements MiddlewareInterface
         $event = new GetResponseEvent($this->kernel, $symfonyRequest, HttpKernel::MASTER_REQUEST);
         $this->dispatcher->dispatch(KernelEvents::REQUEST, $event);
 
+        SymfonyBootstrap::setRequestForTermination($symfonyRequest);
+
         $request = $this->psrHttpFactory->createRequest($symfonyRequest);
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         $response = $handler->handle($request);
 
         $symfonyResponse = $this->httpFoundationFactory->createResponse($response);
-        SymfonyBootstrap::setRequestResponseForTermination($symfonyRequest, $symfonyResponse);
+        SymfonyBootstrap::setResponseForTermination($symfonyResponse);
 
         $event = new FilterResponseEvent($this->kernel, $symfonyRequest, HttpKernel::MASTER_REQUEST, $symfonyResponse);
         $this->dispatcher->dispatch(KernelEvents::RESPONSE, $event);
@@ -107,7 +109,7 @@ class PrepareContentElementRenderer implements MiddlewareInterface
         $this->requestStack->pop();
 
         $symfonyResponse = $event->getResponse();
-        SymfonyBootstrap::setRequestResponseForTermination($symfonyRequest, $symfonyResponse);
+        SymfonyBootstrap::setResponseForTermination($symfonyResponse);
 
         $response = $this->psrHttpFactory->createResponse($symfonyResponse);
 

--- a/Middleware/SymfonyRouteResolver.php
+++ b/Middleware/SymfonyRouteResolver.php
@@ -81,8 +81,10 @@ class SymfonyRouteResolver implements MiddlewareInterface
         }
 
         $symfonyRequest = $this->httpFoundationFactory->createRequest($request);
+        SymfonyBootstrap::setRequestForTermination($symfonyRequest);
+
         $symfonyResponse = $this->kernel->handle($symfonyRequest, HttpKernelInterface::MASTER_REQUEST, false);
-        SymfonyBootstrap::setRequestResponseForTermination($symfonyRequest, $symfonyResponse);
+        SymfonyBootstrap::setResponseForTermination($symfonyResponse);
 
         return $this->psrHttpFactory->createResponse($symfonyResponse);
     }


### PR DESCRIPTION
Terminate the kernel only if the Symfony Request and Response models are set (both will be unset whenever a TYPO3 static route is requested).