### PR TITLE
Use service locator instead of lazy services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add `alias` attribute to `bartacus.makeInstance` tag
+
 ### Changed
 - Use service locator instead of lazy services for `bartacus.make_instance` services
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Use service locator instead of lazy services for `bartacus.make_instance` services
 
 ## [2.2.0] - 2019-08-02
 ### Added

--- a/DependencyInjection/Compiler/SymfonyServiceForMakeInstancePass.php
+++ b/DependencyInjection/Compiler/SymfonyServiceForMakeInstancePass.php
@@ -23,31 +23,41 @@ declare(strict_types=1);
 
 namespace Bartacus\Bundle\BartacusBundle\DependencyInjection\Compiler;
 
+use Bartacus\Bundle\BartacusBundle\Typo3\MakeInstanceServiceLocator;
 use Bartacus\Bundle\BartacusBundle\Typo3\SymfonyServiceForMakeInstanceLoader;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 class SymfonyServiceForMakeInstancePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has(SymfonyServiceForMakeInstanceLoader::class)) {
+        if (!$container->has(SymfonyServiceForMakeInstanceLoader::class) || !$container->has(MakeInstanceServiceLocator::class)) {
             return;
         }
 
-        $definition = $container->findDefinition(SymfonyServiceForMakeInstanceLoader::class);
-
         $taggedServices = $container->findTaggedServiceIds('bartacus.make_instance');
+
+        $classNames = [];
+        $locatableServices = [];
 
         foreach ($taggedServices as $id => $tags) {
             $taggedDefinition = $container->findDefinition($id);
-            $taggedDefinition->setLazy(true);
+            $class = $taggedDefinition->getClass();
 
-            $definition->addMethodCall(
-                'addService',
-                [$taggedDefinition->getClass(), new Reference($id)]
-            );
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+            }
+
+            $class = $r->name;
+            $classNames[] = $class;
+            $locatableServices[$class] = new Reference($id);
         }
+
+        $container->findDefinition(SymfonyServiceForMakeInstanceLoader::class)->replaceArgument(0, $classNames);
+        $container->findDefinition(MakeInstanceServiceLocator::class)->addArgument(ServiceLocatorTagPass::register($container, $locatableServices));
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -102,6 +102,11 @@
             <tag name="twig.extension" />
         </service>
 
-        <service id="Bartacus\Bundle\BartacusBundle\Typo3\SymfonyServiceForMakeInstanceLoader" public="true" />
+        <service id="Bartacus\Bundle\BartacusBundle\Typo3\SymfonyServiceForMakeInstanceLoader" public="true">
+            <argument /> <!-- class names -->
+            <argument type="service" id="Bartacus\Bundle\BartacusBundle\Typo3\MakeInstanceServiceLocator" />
+        </service>
+
+        <service id="Bartacus\Bundle\BartacusBundle\Typo3\MakeInstanceServiceLocator" />
     </services>
 </container>

--- a/Resources/doc/services_typo3.rst
+++ b/Resources/doc/services_typo3.rst
@@ -9,10 +9,9 @@ This would prevent the use of proper DI
 
 Fortunately Bartacus integrates the service container into TYPO3 so the call
 ``GeneralUtility::makeInstace()`` for configured classes automatically
-transformed into a (lazy) service container load.
+transformed into a service container load from a service locator.
 
-It doesn't matter if you use old snake cased service ids or the new PSR-4
-service id naming.
+It doesn't matter if you use classic service ids or the new PSR-4 service id naming.
 
 makeInstance calls
 ==================

--- a/Resources/doc/services_typo3.rst
+++ b/Resources/doc/services_typo3.rst
@@ -73,6 +73,16 @@ Some of the TYPO3 interfaces are already registered for autoconfiguration, so yo
 
 * ``TYPO3\CMS\Install\Updates\UpgradeWizardInterface``
 
+If you need to add your specific class for ``makeInstance`` in replacement of another class or interface, you can add the `alias` attribute:
+
+.. code-block:: yaml
+
+    // config/services.yml
+    services:
+        App\Mail\AcmeTransport:
+            tags:
+                - { name: bartacus.make_instance, alias: Swift_Transport }
+
 Usage
 -----
 

--- a/Typo3/MakeInstanceServiceLocator.php
+++ b/Typo3/MakeInstanceServiceLocator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Bartacus project, which integrates Symfony into TYPO3.
+ *
+ * Copyright (c) Emily Karisch
+ *
+ * The BartacusBundle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BartacusBundle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the BartacusBundle. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Bartacus\Bundle\BartacusBundle\Typo3;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+class MakeInstanceServiceLocator implements \ArrayAccess
+{
+    /**
+     * @var ServiceLocator
+     */
+    private $serviceLocator;
+
+    /**
+     * @var object[]
+     */
+    private $singletonInstances = [];
+
+    public function __construct(ServiceLocator $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    public function offsetExists($id): bool
+    {
+        return $this->serviceLocator->has($id) || isset($this->singletonInstances[$id]);
+    }
+
+    public function offsetGet($id): object
+    {
+        return $this->serviceLocator->has($id) ? $this->serviceLocator->get($id) : $this->singletonInstances[$id];
+    }
+
+    public function offsetSet($id, $service): void
+    {
+        $this->singletonInstances[$id] = $service;
+    }
+
+    public function offsetUnset($id): void
+    {
+        unset($this->singletonInstances[$id]);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-3.0+
| Documentation License | CC BY-SA 4.0

#### What's in this PR?

Uses a service locator instead of lazy services for the `GeneralUtility::makeInstance` calls. As it replaces the `$singletonInstances` cache, a wrapper with array access is added to store additional instances.

Supporting also a new alias attribute for adding services for interfaces or replacing classes.
